### PR TITLE
Update crawl-gear skill: Sea to Summit adapter + Korean naming

### DIFF
--- a/.claude/skills/crawl-gear/SKILL.md
+++ b/.claude/skills/crawl-gear/SKILL.md
@@ -110,7 +110,7 @@ HTML 카드 그리드에서 확인:
 
 | 사이트 유형 | 식별 단서 | 주요 셀렉터 |
 |---|---|---|
-| **Shopify** | `cdn.shopify.com` 자산, `.shopify-section`, `/collections/` | `.card-wrapper`/`.grid__item`, `.card__heading`. **`products.json` API 우선** (무게 `grams` 포함) |
+| **Shopify** | `cdn.shopify.com` 자산, `.shopify-section`, `/collections/` | `.card-wrapper`/`.grid__item`, `.card__heading`. **리스팅·이미지·변형은 `products.json` API 우선.** 단 `grams`는 배송무게라 부정확 → 무게/스펙은 상세 페이지 스펙 테이블에서. 색상별 이미지는 `variant.featured_image.src` |
 | **WooCommerce** | `/product-category/`, `wp-content` | `ul.products li.product`, `h3.product-title` |
 | **Magento** | `/catalog/category/view/`, `magento` | `.product-item`, `.product-info` |
 | **Algolia 검색** | `ais-*` 클래스 | `.ais-InfiniteHits-item`, `.ais-Hits-item` |
@@ -324,11 +324,49 @@ etc
 | pouch / backpack_cover | material, isWaterproof, capacity |
 | tent_acc / pillow / food / towel / hand_warmer / shovel / hammer / microspikes / etc | material, size |
 
-## 변형 처리
+## 변형 처리 (Sea to Summit 세션에서 확립한 룰)
 
-같은 제품의 색상/사이즈/무게가 다르면 별도 행, 같은 `groupId`로 묶임.
+같은 제품의 색상/사이즈/온도가 다르면 **별도 행**, 같은 `groupId`로 묶임.
 
-현재는 리스팅에 노출된 색상 1개만 추출 (간단). 다른 색상은 같은 URL 슬러그면 같은 `groupId`로 묶이도록 설계됨. 다중 색상 추출은 사이트마다 별도 작업.
+**핵심 룰:**
+- **옵션(사이즈·색상·온도)별로 모두 개별 제품으로 수집.** Shopify면 `products.json`의 `variants` 전체를 순회해 한 변형당 한 행. (예: 4사이즈×7색상 = 28행)
+- **사이즈를 영문 `name` 끝에 부착** (예: `Ascent Down Sleeping Bag Long / 15°F`). 사이즈+온도 등 비색상 옵션을 ` / `로 이어붙임.
+- **`One Size` / `Default Title` 은 사이즈 없음으로 처리** — `size`/`sizeKorean` 빈값, 이름에도 안 붙임.
+- **색상별 이미지를 각각 수집.** Shopify 컬렉션 `products.json`은 variant에 `image_id`가 없고 **`variant.featured_image.src`** 에 색상별 사진을 담는다 (개별 `product.json`은 `image_id` 사용). featured_image 우선.
+
+**무게·스펙은 변형 인덱스가 아니라 "스펙 컬럼 헤더"로 매핑한다 (중요):**
+- 스펙 테이블 컬럼 수 < 변형 수인 경우가 흔하다 (스펙은 사이즈/온도별, 색상엔 무관). 변형 인덱스(vi)로 컬럼을 읽으면 색상 변형이 전부 어긋나 0/오값이 된다.
+- 각 변형의 **비색상 옵션값(사이즈·온도)** 을 스펙 테이블 **헤더 라벨** 과 매칭해 컬럼을 찾고, 그 컬럼에서 무게/온도/충전재를 읽는다.
+
+**무게 추출 룰:**
+- 우선순위: `Packed Weight` → `Weight` → `Set Weight` (쿡세트류는 Set Weight만 있음).
+- **Shopify `variants[].grams` 는 배송무게라 부정확** — 스펙 테이블 값을 쓴다.
+- 단위 토글(metric/imperial)이 `<span class="met">`/`<span class="imp">`로 동시 렌더되면 **met(미터법) 값만** 추출 (버튼 클릭 불필요).
+- **반올림 금지** — 사이트 표기 그대로 (예: `527.1g`).
+
+## 한글화 (nameKorean / sizeKorean / colorKorean)
+
+영문 카탈로그를 한글명까지 채우는 워크플로우 (Sea to Summit 세션에서 확립). 참고 구현: `kr-reference.js`, `kr-match.js`, `kr-apply.js`.
+
+**원칙: 한국 공식 수입사/유통사 사이트에서 동일 제품을 찾으면 그 공식 한글명을 그대로(verbatim) 쓰고, 못 찾으면 음역으로 생성.**
+
+### 1. KR 레퍼런스 수집 (`kr-reference.js` 패턴)
+- 브랜드의 **한국 공식 수입사 사이트**를 찾는다 (예: 씨투써밋 → 니오 seatosummit.co.kr). 봇차단(403)은 User-Agent 헤더로 우회.
+- 카테고리 리스트 → `(제품코드, 한글명)`, 상세 페이지 → **영문 모델명** 추출 → `{en, ko}` 레퍼런스 구축. (KR 사이트는 보통 한글명만 노출하고 상세에 영문명이 있어, 영문명이 매칭 키가 됨.)
+
+### 2. 변형 단위 매칭 (핵심 룰)
+**동일 제품 판정은 모델 + 온도 + 사이즈 + 색상 + 타입이 "모두" 일치해야 한다.** 하나라도 다르면 다른 제품 → 생성으로 폴백. (라인 단위로 대충 매칭하면 US 15°F 변형에 KR -10도 이름이 박히는 오류 발생.)
+- 가드 예시: 침낭 `limitTemp(℃)` ↔ KR "N도", 매트 자충(SI)/에어 타입, 침낭 다운/신세틱, 텐트 TR코드, 사이즈/용량 충돌.
+- 매칭됨 → **KR 공식명 verbatim**. 공식명에 사이즈가 없으면 끝에 `sizeKorean` 부착.
+- 미매칭 → **음역 생성** (모델라인 음역 + 한글 카테고리어) + `sizeKorean`.
+
+### 3. sizeKorean 규칙
+- 단어형 음역: Regular→레귤러, Long→롱, Small→스몰, Large→라지, S/M/L/XL→스몰/미디엄/라지/엑스라지, Wide→와이드, Rectangular→렉탱귤러.
+- **온도 °F→℃ 변환** (예: 15°F→-9℃). 용량(5L)·텐트코드(TR2)·인치(10in)는 그대로. One Size/Default→빈값.
+- 매칭 시엔 KR 표기(약어 LG/RG/사각 등)와 음역을 같은 사이즈로 취급(canonical)해 중복 부착 방지.
+
+### 4. colorKorean 규칙
+- KR 사이트 표기 스타일로 음역 (Beluga→벨루가, Tarragon→타라곤, Spicy Orange→스파이시 오렌지). 멀티컬러는 `/`로 분리해 각각 변환.
 
 ## 사전 준비
 
@@ -337,6 +375,7 @@ etc
 스킬 파일·데이터는 레포에 포함돼 git clone 으로 동기화된다. 추가로 필요한 것:
 
 1. **Node 의존성** — 레포 루트에서 `npm install` (이미 `package.json` 에 `puppeteer`, `firebase-admin` 선언됨). 워크트리면 글로벌 규칙대로 메인 클론 `node_modules` 를 심링크.
+   - **Node 버전 주의:** 크롤(`crawl.js`)은 최신 Node 무방하지만, **Firestore push(firebase-admin)는 Node 20 LTS 로 실행**해야 한다. Node 22+(특히 26)에선 firebase-admin 의 전이 의존성이 제거된 `SlowBuffer` 를 참조해 크래시한다. 푸시만 `node@20` 바이너리로: `/opt/homebrew/opt/node@20/bin/node server.js`.
 2. **Pillow (선택)** — `nemo-specs.py` / `nemo-findtable.py`(한국 고시 이미지 크롭) 사용 시에만. `python3 -m pip install Pillow`. 글로벌 사이트 스크래퍼(`*-global.py`)는 표준 라이브러리만 쓰므로 불필요.
 3. **serviceAccountKey.json** — Firestore push 시점에만 (아래). 머신마다 수동 추가.
 
@@ -367,3 +406,8 @@ Firebase Console → 프로젝트 설정 → 서비스 계정 → "새 비공개
 - weight=0 다수 → 상세 페이지 무게 정규식이 사이트와 안 맞음. `fetchDetail`의 regex 수정
 - specs 비어있음 → 해당 카테고리 블록을 어댑터 `fetchDetail`에 추가 필요
 - Firestore 권한 오류 → serviceAccountKey.json 누락
+- **무게/온도가 색상 변형에서만 0/오값** → 변형 인덱스로 스펙 컬럼을 읽고 있는 것. 헤더 라벨(사이즈/온도) 매칭으로 컬럼을 찾아야 함 (위 "변형 처리" 참고)
+- **무게가 정수로 깎임** → `parseWeight`에서 `Math.round` 제거, met span 값 그대로
+- **HTML "저장" 시 서버 연결 실패** → 푸시 서버 미실행. `node@20 server.js`로 포트 3847 기동 (`--from-json`은 서버 안 띄움). `lsof -ti:3847`로 확인
+- **firebase-admin `SlowBuffer` 크래시** → Node 버전 너무 최신. `node@20`으로 푸시
+- **네이버 스마트스토어 등 강차단 쇼핑몰** → 서버 fetch는 429, Claude in Chrome도 쇼핑몰 안전제한으로 차단되어 현재 도구로 크롤 불가. 공식 브랜드 사이트를 우선 타깃으로

--- a/.claude/skills/crawl-gear/kr-apply.js
+++ b/.claude/skills/crawl-gear/kr-apply.js
@@ -1,0 +1,352 @@
+// Fill nameKorean + sizeKorean on the S2S crawl output (variant-level matching).
+//
+// Rule (per user):
+//  - A KR product is the SAME product only if model + temperature + size + color all match.
+//  - Matched variant → KR official name verbatim; if it lacks the size, append sizeKorean.
+//  - No exact variant match → transliterated base (KO_BASE) + sizeKorean.
+//
+// Temperature: US sleeping bags expose specs.limitTemp (℃); KR names embed "N도".
+// Color: our crawl rarely captures color, so it acts as a wildcard (we prefer
+//        KR entries without a baked-in color to avoid picking an arbitrary one).
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const outDir = join(__dirname, 'out');
+
+// ── clean line-level Korean (transliteration) for the generation fallback ──
+const KO_BASE = {
+  // sleeping_bag
+  'alpine-down-sleeping-bag': '알파인 다운 침낭',
+  'the-ascent-down-sleeping-bag': '아센트 다운 침낭',
+  'ascent-womens-down-sleeping-bag': '아센트 여성용 다운 침낭',
+  'basecamp-down-sleeping-bag': '베이스캠프 다운 침낭',
+  'boab-synthetic-sleeping-bag': '보아브 신세틱 침낭',
+  'the-ember-down-quilt': '엠버 다운 퀼트',
+  'hamelin-synthetic-sleeping-bag': '하멜린 신세틱 침낭',
+  'hamelin-womens-synthetic-sleeping-bag': '하멜린 여성용 신세틱 침낭',
+  'spark-down-sleeping-bag': '스파크 다운 침낭',
+  'spark-pro-down-sleeping-bag': '스파크 프로 다운 침낭',
+  'spark-womens-down-sleeping-bag': '스파크 여성용 다운 침낭',
+  'tanami-down-comforter': '타나미 다운 컴포터',
+  'the-traveller-down-sleeping-bag': '트래블러 다운 침낭',
+  'trek-down-sleeping-bag': '트렉 다운 침낭',
+  'trek-womens-down-sleeping-bag': '트렉 여성용 다운 침낭',
+  // mat
+  'air-chair': '에어 체어',
+  'air-seat': '에어 시트',
+  'air-seat-insulated': '에어 시트 인슐레이티드',
+  'air-sprung-cell-mat-repair-kit': '에어 매트리스 리페어 키트',
+  'air-stream-dry-sack-pump': '에어스트림 펌프 색',
+  'camp-plus-self-inflating-sleeping-pad': '캠프 플러스 자충 매트리스',
+  'camp-self-inflating-pad': '캠프 자충 매트리스',
+  'camp-self-inflating-pad-past-season': '캠프 자충 매트리스',
+  'comfort-deluxe-self-inflating-sleeping-pad': '컴포트 디럭스 자충 매트리스',
+  'comfort-light-insulated-pad': '컴포트 라이트 인슐레이티드 에어 매트리스',
+  'comfort-light-insulated-womens-sleeping-pad': '컴포트 라이트 인슐레이티드 여성용 에어 매트리스',
+  'comfort-plus-insulated-pad': '컴포트 플러스 인슐레이티드 에어 매트리스',
+  'delta-self-inflating-seat': '델타 자충 시트',
+  'ether-light-xr-insulated-air-sleeping-pad': '에테르 라이트 XR 인슐레이티드 에어 매트리스',
+  'ether-light-xr-pro-insulated-air-sleeping-pad': '에테르 라이트 XR 프로 인슐레이티드 에어 매트리스',
+  'mat-coupler-kit-loops': '매트 커플러 키트 루프',
+  'pursuit-plus-self-inflating-sleeping-pad': '퍼수트 플러스 자충에어 매트리스',
+  'pursuit-self-inflating-sleeping-pad': '퍼수트 자충에어 매트리스',
+  'ultralight-sleeping-pad': '울트라라이트 에어 매트리스',
+  'ultralight-insulated-mat': '울트라라이트 인슐레이티드 에어 매트리스',
+  'ultralight-insulated-womens-sleeping-pad': '울트라라이트 인슐레이티드 여성용 에어 매트리스',
+  'ultralight-xr-insulated-air-sleeping-pad': '울트라라이트 XR 인슐레이티드 에어 매트리스',
+  // pillow
+  'aeros-down-pillow': '에어로 필로우 다운 베개',
+  'aeros-pillow-premium': '에어로 필로우 프리미엄 베개',
+  'aeros-pillow-premium-past-season': '에어로 필로우 프리미엄 베개',
+  'aeros-premium-traveller-pillow': '에어로 필로우 프리미엄 트래블러 베개',
+  'aeros-pillow-ultra-light': '에어로 필로우 울트라라이트 베개',
+  'aeros-pillow-ultra-light-past-season': '에어로 필로우 울트라라이트 베개',
+  'aeros-traveller-pillow': '에어로 필로우 울트라라이트 트래블러 베개',
+  'foam-core-pillow': '폼 코어 베개',
+  'memory-lux-pillow': '메모리 럭스 베개',
+  // tent
+  'ikos-evo-tent': '아이코스 에보 텐트',
+  'telos-evo-bikepack-tent': '텔러스 에보 바이크팩 텐트',
+  'telos-evo-tent': '텔러스 에보 텐트',
+  // tarp
+  'escapist-evo-tarp': '이스캐피스트 에보 타프',
+  'escapist-mesh-bug-shelter': '이스캐피스트 메쉬 버그 쉘터',
+  'minimalist-tarp': '미니멀리스트 타프',
+  'ultra-sil-nano-tarp-poncho': '울트라실 나노 타프 판초',
+  // tent_acc
+  'alto-bigfoot-footprint': '알토 빅 풋프린트',
+  'alto-gear-loft': '알토 기어 로프트',
+  'alto-lightfoot-footprint': '알토 라이트 풋프린트',
+  'ground-control-guy-cords': '그라운드 컨트롤 가이 코드',
+  'light-tent-pegs': '그라운드 컨트롤 라이트 텐트 펙',
+  'ground-control-tent-pegs': '그라운드 컨트롤 텐트 펙',
+  'telos-hangout-pole-set-grey': '텔러스 행아웃 폴 세트',
+  'ikos-footprint': '아이코스 풋프린트',
+  'telos-bigfoot-footprint': '텔러스 빅 풋프린트',
+  'telos-gear-loft': '텔러스 기어 로프트',
+  'telos-lightfoot-footprint': '텔러스 라이트 풋프린트',
+  'utensil-peg-bag': '울트라실 펙 & 유텐실 백',
+  // cookware_etc
+  'detour-essential-kitchen-kit': '디투어 에센셜 캠프 키친 키트',
+  'detour-collapsible-kettle': '디투어 접이식 케틀',
+  'detour-collapsible-pot': '디투어 접이식 팟',
+  'detour-collapsible-pouring-pot': '디투어 접이식 푸어링 팟',
+  'detour-stainless-steel-kettle-cookset': '디투어 케틀 쿡 세트',
+  'detour-5-piece-cookset': '디투어 원 팟 쿡 세트',
+  'detour-stainless-steel-pan': '디투어 팬',
+  'frontier-collapsible-pouring-pot': '프론티어 접이식 푸어링 팟',
+  'frontier-ultralight-3-piece-cookset': '프론티어 원 팟 쿡 세트',
+  'frontier-collapsible-kettle': '프론티어 접이식 케틀',
+  'frontier-collapsible-kettle-cookset': '프론티어 케틀 쿡 세트',
+  'frontier-collapsible-3-piece-kettle-cookset': '프론티어 케틀 쿡 세트',
+  'frontier-collapsible-5-piece-cookset': '프론티어 원 팟 쿡 세트',
+  'frontier-ultralight-collapsible-one-pot-cook-set': '프론티어 원 팟 쿡 세트',
+  'frontier-ultralight-collapsible-pot': '프론티어 접이식 팟',
+  'frontier-ultralight-pour-over': '프론티어 접이식 드리퍼',
+  'frontier-ultralight-one-pot-cookset': '프론티어 원 팟 쿡 세트',
+  'frontier-ultralight-5-piece-cookset': '프론티어 원 팟 쿡 세트',
+  'frontier-ultralight-pan': '프론티어 팬',
+  'frontier-ultralight-pot': '프론티어 팟',
+  'frontier-ultralight-14-piece-cookset': '프론티어 투 팟 쿡 세트',
+  'frontier-ultralight-6-piece-cookset': '프론티어 투 팟 쿡 세트',
+  'frontier-ultralight-two-pot-cookset': '프론티어 투 팟 세트',
+  // cup
+  'detour-collapsible-mug': '디투어 접이식 머그',
+  'frontier-collapsible-cup': '프론티어 접이식 컵',
+  'frontier-ultralight-collapsible-kettle-cook-set-with-cups-used': '프론티어 케틀 쿡 세트',
+  'passage-cup': '패시지 컵',
+  'passage-insulated-mug': '패시지 인슐레이티드 머그',
+  // bowl
+  'detour-stainless-steel-bowl': '디투어 접이식 보울',
+  'detour-collapsible-6-piece-dinnerware': '디투어 접이식 디너웨어 세트',
+  'frontier-collapsible-bowl': '프론티어 접이식 보울',
+  'frontier-collapsible-3-piece-dinnerware': '프론티어 접이식 디너웨어 세트',
+  'frontier-collapsible-6-piece-dinnerware': '프론티어 접이식 디너웨어 세트',
+  'passage-bowl': '패시지 보울',
+  'passage-dinnerware-set-7-piece-used': '패시지 디너웨어 세트',
+  'passage-dinnerware-set': '패시지 디너웨어 세트',
+  'passage-dinnerware-6-piece-set': '패시지 디너웨어 세트',
+  // cutlery
+  'camp-fork': '캠프 커틀러리 포크',
+  'camp-knife': '캠프 커틀러리 나이프',
+  'camp-cutlery-spoon-fork-knife-set': '캠프 커틀러리 세트',
+  'camp-spoon': '캠프 커틀러리 스푼',
+  'camp-kitchen-tool-kit-10-piece-set': '캠프 키친 툴 키트',
+  'detour-stainless-steel-chopsticks': '디투어 젓가락',
+  'detour-stainless-steel-cultery-set': '디투어 커틀러리 세트',
+  'detour-stainless-steel-6-piece-cutlery-set': '디투어 커틀러리 세트',
+  'detour-stainless-steel-kitchen-knife': '디투어 키친 나이프',
+  'detour-stainless-steel-pairing-knife': '디투어 페어링 나이프',
+  'detour-utensil-set': '디투어 커틀러리 세트',
+  'folding-serving-spoon': '캠프 키친 폴딩 서빙 스푼',
+  'folding-spatula': '캠프 키친 폴딩 스패츌라',
+  'frontier-ultralight-cutlery-set': '프론티어 커틀러리 롱 핸들 세트',
+  'frontier-ultralight-spork-knife-set': '프론티어 커틀러리 세트',
+  'frontier-ultralight-cultery-set': '프론티어 커틀러리 세트',
+  'frontier-ultralight-long-spoon': '프론티어 롱 핸들 스푼',
+  'frontier-ultralight-spork': '프론티어 스포크',
+  'frontier-ultralight-long-spork': '프론티어 롱 핸들 스포크',
+  'frontier-ultralight-short-handle-spork': '프론티어 숏 핸들 스포크',
+  'horizon-cutlery-set-2-piece': '호라이즌 커틀러리 세트',
+  'passage-2-piece-cutlery-set': '패시지 커틀러리 세트',
+  'passage-cutlery': '패시지 커틀러리 세트',
+  // towel
+  'airlite-towel': '에어라이트 타월',
+  'drylite-towel': '드라이라이트 타월',
+  'pocket-towel': '포켓 타월',
+  'tek-towel': '텍 타월',
+  // pouch
+  'big-river-dry-backpack': '빅 리버 드라이 백팩',
+  'the-big-river-dry-bag': '빅 리버 드라이 백',
+  'dry-bag-sling': '드라이 백 슬링',
+  'evac-compression-dry-bag-hd': '이벤트 컴프레션 드라이 백 헤비 듀티',
+  'the-evac-compression-dry-bag': '이벤트 컴프레션 UL 드라이 백',
+  'the-evac-dry-bag': '이벤트 드라이 백',
+  'evac-compression-dry-bag-ul': '이벤트 컴프레션 UL 드라이 백',
+  'lightweight-dry-bag': '라이트웨이트 드라이 백',
+  'lightweight-first-aid-dry-bag': '라이트웨이트 퍼스트 에이드 드라이 백',
+  'lightweight-dry-bag-set': '라이트웨이트 드라이 백 세트',
+  'lightweight-dry-bag-view': '라이트웨이트 뷰 드라이 백',
+  'lightweight-stuff-sack': '라이트웨이트 스터프 색',
+  'lightweight-stuff-sack-set': '라이트웨이트 스터프 색 세트',
+  'mesh-stuff-sack-set': '메쉬 스터프 색 세트',
+  'ultra-sil-dry-bag': '울트라실 드라이 백',
+  'ultra-sil-dry-bag-set': '울트라실 드라이 백 세트',
+  'the-ultra-sil-stuff-sack': '울트라실 스터프 색',
+  'the-ultra-sil-stuff-sack-set': '울트라실 스터프 색 세트',
+};
+
+// ── size → Korean ────────────────────────────────────────────────
+const WORD = {
+  regular: '레귤러', long: '롱', short: '숏', small: '스몰', large: '라지',
+  wide: '와이드', rectangular: '렉탱귤러', contour: '컨투어', deluxe: '디럭스',
+  double: '더블', tapered: '테이퍼드', standard: '스탠다드', extra: '엑스트라',
+  xs: '엑스스몰', s: '스몰', m: '미디엄', l: '라지', xl: '엑스라지',
+  "women's": '여성용', womens: '여성용', "men's": '남성용', mens: '남성용',
+  piece: '피스', pack: '팩',
+};
+const SPECIAL = { 'default title': '', 'one size': '원사이즈', queen: '퀸', single: '싱글', king: '킹' };
+
+const mapSizePart = (part) => {
+  const p = part.trim();
+  if (!p) return '';
+  const low = p.toLowerCase();
+  if (low in SPECIAL) return SPECIAL[low];
+  const tf = p.match(/^(-?\d+)\s*°?\s*F$/i);
+  if (tf) return `${Math.round((parseInt(tf[1], 10) - 32) * 5 / 9)}℃`;
+  return p.replace(/[[\]]/g, ' ').split(/\s+/).filter(Boolean).map((w) => WORD[w.toLowerCase()] ?? w).join(' ');
+};
+const mapSize = (size) => (size || '').split('/').map(mapSizePart).filter(Boolean).join(' / ');
+
+// ── color → Korean (KR-site style transliteration) ────────────────
+const COLOR = {
+  'beluga': '벨루가', 'spicy orange': '스파이시 오렌지', 'picante': '피칸테',
+  'aqua sea': '아쿠아 씨', 'high rise': '하이 라이즈', 'surf the web': '서프 더 웹',
+  'blue atoll': '블루 아톨', 'burnt olive': '번트 올리브', 'turkish tile': '터키시 타일',
+  'zinnia': '지니아', 'desert': '데저트', 'sage': '세이지', 'sulphur': '설퍼',
+  'arrowwood': '애로우우드', 'jet black': '제트 블랙', 'moonlight': '문라이트',
+  'tarragon': '타라곤', 'moonlight blue': '문라이트 블루', 'grey': '그레이',
+  'dull gold': '덜 골드', 'mediterranea': '메디테라네아', 'lime': '라임',
+  'moonstruck': '문스트럭', 'magenta': '마젠타', 'navy': '네이비',
+  'cendre blue': '센드레 블루', 'burnt orange': '번트 오렌지', 'outback': '아웃백',
+  'baltic': '발틱', 'desert brown': '데저트 브라운', 'sage green': '세이지 그린',
+  'cabbage': '캐비지', 'starfish': '스타피쉬', 'bombay brown': '봄베이 브라운',
+  'sea foam': '씨 폼', 'puffins bill': '퍼핀스 빌', 'bone white': '본 화이트',
+  'laurel wreath': '로렐 리스', 'blue': '블루', 'arrowwood yellow': '애로우우드 옐로우',
+  'bombay': '봄베이', 'charcoal': '차콜',
+};
+const mapColor = (color) =>
+  (color || '')
+    .split('/')
+    .map((c) => { const k = c.trim().toLowerCase(); return COLOR[k] ?? c.trim(); })
+    .filter(Boolean)
+    .join('/');
+
+// Korean size words we care about for variant matching
+const SIZE_WORDS = ['레귤러', '롱', '숏', '스몰', '미디엄', '라지', '엑스라지', '엑스스몰', '와이드', '사각', '더블', '싱글', '컨투어', '디럭스'];
+// KR abbreviations → canonical Korean size word
+const KR_ABBR = { LG: '라지', RG: '레귤러', MD: '미디엄', SM: '스몰', XL: '엑스라지', XSM: '엑스스몰', RT: '사각', LT: '롱' };
+
+const sizeWordsOf = (text) => {
+  const found = new Set();
+  for (const w of SIZE_WORDS) if (text.includes(w)) found.add(w);
+  for (const [ab, ko] of Object.entries(KR_ABBR)) {
+    if (new RegExp(`(?:^|[^A-Za-z])${ab}(?:[^A-Za-z]|$)`).test(text)) found.add(ko);
+  }
+  // canonicalise rectangular: display '렉탱귤러' and KR '사각' are the same size for matching
+  if (/렉탱귤러/.test(text)) found.add('사각');
+  return found;
+};
+// volumes like 5L / 1.5L / 20 (litre)
+const volumesOf = (text) => new Set([...text.matchAll(/(\d+(?:\.\d+)?)\s*(?:L|리터|litre|liter)\b/gi)].map((m) => m[1]));
+
+// ── English token normalisation for model-line matching ──
+const STOP = new Set(['the', 'with', 'and', 'a', 'of', 'for', 's2s', 'sea', 'to', 'summit', 'past', 'season', 'new',
+  'sleeping', 'bag', 'pad', 'mat', 'mattress', 'air', 'insulated', 'self', 'inflating', 'si', 'down', 'synthetic',
+  'series', 'womens', 'women', 'mens', 'men', 'ul', 'asc', 'rcs']);
+const enTokens = (s) => new Set((s || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').split(/\s+/).filter((t) => t && !STOP.has(t)));
+const subset = (a, b) => { for (const t of a) if (!b.has(t)) return false; return true; };
+
+// ── load data ────────────────────────────────────────────────────
+const crawlFile = process.argv[2] ||
+  readdirSync(outDir).filter((f) => /^sea-to-summit-\d+\.json$/.test(f)).sort().at(-1);
+const crawl = JSON.parse(readFileSync(join(outDir, crawlFile)));
+const ref = JSON.parse(readFileSync(join(outDir, 'seatosummit-kr-ref.json')));
+
+const refParsed = ref
+  .filter((r) => r.en && r.ko)
+  .map((r) => ({
+    ko: r.ko,
+    en: r.en,
+    tk: enTokens(r.en),
+    tempC: (r.ko.match(/(-?\d+)\s*도/) ?? [])[1] != null ? parseInt(r.ko.match(/(-?\d+)\s*도/)[1], 10) : null,
+    sizes: sizeWordsOf(r.ko),
+    vols: volumesOf(r.ko),
+    hasColor: /그린|그레이|블루|레드|오렌지|옐로우|블랙|타라곤|벨루가|인디고|내추럴|애플그린|네이비|차콜|퍼시픽|쉘|아로우|샌드|코랄/.test(r.ko),
+    // pad type: 자충 → self-inflating, else air/insulated
+    padType: /자충/.test(r.ko) ? 'self-inflating' : (/에어|인슐레이티드/.test(r.ko) ? 'air' : null),
+    // bag fill: 다운 → down, else (침낭 without 다운) synthetic
+    bagFill: /침낭/.test(r.ko) ? (/다운/.test(r.ko) ? 'down' : 'synthetic') : null,
+    // tent TR code
+    tr: ((r.en + ' ' + r.ko).match(/TR\s*(\d)/i) ?? [])[1] ?? null,
+  }));
+
+// US item → its key facts
+const usFacts = (it, base) => {
+  const tk = enTokens(base);
+  const tempC = it.category === 'sleeping_bag' && typeof it.specs?.limitTemp === 'number' ? it.specs.limitTemp : null;
+  const sizeKo = mapSize(it.size);
+  const sizes = sizeWordsOf(sizeKo);
+  const vols = new Set([...((it.size || '').matchAll(/(\d+(?:\.\d+)?)\s*L\b/gi))].map((m) => m[1]));
+  const padType = it.category === 'mat' ? (it.specs?.type ?? null) : null;
+  const bagFill = it.category === 'sleeping_bag' ? (it.specs?.fillMaterial ?? null) : null;
+  const tr = ((it.size || '').match(/TR\s*(\d)/i) ?? [])[1] ?? null;
+  return { tk, tempC, sizeKo, sizes, vols, padType, bagFill, tr };
+};
+
+// find best exact-variant KR match (model + temp + size + volume compatible)
+const matchKR = (f) => {
+  const cands = refParsed.filter((r) => {
+    if (!f.tk.size || !subset(f.tk, r.tk)) return false;            // model line must be covered
+    if (f.tempC != null && r.tempC !== f.tempC) return false;        // temp must match exactly
+    if (f.tempC == null && r.tempC != null) return false;            // KR is a temp variant, US isn't → different
+    // pad type (self-inflating vs air) must match
+    if (f.padType && r.padType && f.padType !== r.padType) return false;
+    // bag fill (down vs synthetic) must match
+    if (f.bagFill && r.bagFill && f.bagFill !== r.bagFill) return false;
+    // tent TR code must match
+    if (f.tr && r.tr && f.tr !== r.tr) return false;
+    if (f.tr && !r.tr) return false;
+    // size compatibility: KR size words must not conflict with US size
+    if (r.sizes.size && f.sizes.size && !subset(f.sizes, r.sizes)) return false;
+    if (r.sizes.size && !f.sizes.size) return false;                 // KR pins a size we don't have
+    // volume compatibility
+    if (r.vols.size && f.vols.size && !subset(f.vols, r.vols)) return false;
+    if (r.vols.size && !f.vols.size) return false;
+    return true;
+  });
+  if (!cands.length) return null;
+  // prefer: size present & no baked color, then no-color, then fewest tokens (closest)
+  cands.sort((a, b) =>
+    (b.sizes.size ? 1 : 0) - (a.sizes.size ? 1 : 0) ||
+    (a.hasColor ? 1 : 0) - (b.hasColor ? 1 : 0) ||
+    a.tk.size - b.tk.size);
+  return cands[0];
+};
+
+// ── apply ────────────────────────────────────────────────────────
+let matched = 0, generated = 0; const missing = new Set();
+for (const it of crawl) {
+  const slug = it.groupId.replace('sea-to-summit_', '');
+  const koBase = KO_BASE[slug];
+  if (!koBase) { missing.add(slug); }
+  let base = it.name;
+  if (it.size && base.endsWith(' ' + it.size)) base = base.slice(0, -(it.size.length + 1));
+
+  const f = usFacts(it, base);
+  it.sizeKorean = f.sizeKo;
+  it.colorKorean = mapColor(it.color);
+
+  const kr = matchKR(f);
+  if (kr) {
+    matched++;
+    // KR name already conveys the variant if it covers our size words, volumes, and temp.
+    const sizeCovered = !f.sizes.size || subset(f.sizes, kr.sizes);
+    const volCovered = !f.vols.size || subset(f.vols, kr.vols);
+    const tempCovered = f.tempC == null || kr.tempC === f.tempC;
+    const covered = sizeCovered && volCovered && tempCovered;
+    it.nameKorean = covered || !f.sizeKo ? kr.ko : `${kr.ko} ${f.sizeKo}`;
+    it._krMatch = kr.en;
+  } else {
+    generated++;
+    it.nameKorean = f.sizeKo ? `${koBase ?? base} ${f.sizeKo}` : (koBase ?? base);
+  }
+}
+
+const stamp = Date.now();
+const outPath = join(outDir, `sea-to-summit-ko-${stamp}.json`);
+writeFileSync(outPath, JSON.stringify(crawl, null, 2));
+console.log(`적용 완료: ${crawl.length}항목 (KR매칭 ${matched} / 생성 ${generated}) → ${outPath}`);
+if (missing.size) console.log(`⚠️ KO_BASE 누락:`, [...missing].join(', '));

--- a/.claude/skills/crawl-gear/kr-match.js
+++ b/.claude/skills/crawl-gear/kr-match.js
@@ -1,0 +1,57 @@
+// Match crawled S2S products (English) to KR reference by English-name token overlap.
+// Outputs top-3 KR candidates per unique product → out/kr-match-candidates.json + console table.
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const outDir = join(__dirname, 'out');
+
+const crawlFile = process.argv[2] ||
+  readdirSync(outDir).filter((f) => /^sea-to-summit-\d+\.json$/.test(f)).sort().at(-1);
+const crawl = JSON.parse(readFileSync(join(outDir, crawlFile)));
+const ref = JSON.parse(readFileSync(join(outDir, 'seatosummit-kr-ref.json')));
+
+// Only truly generic words dropped — keep distinguishing nouns (pot/mug/bowl/spork...).
+const STOP = new Set(['the', 'with', 'and', 'a', 'of', 'for', 's2s', 'sea', 'to', 'summit', 'past', 'season', 'new', 'piece']);
+
+const norm = (s) =>
+  (s || '').toLowerCase().replace(/[^a-z0-9°]+/g, ' ').split(/\s+/).filter((t) => t && !STOP.has(t));
+const tokenSet = (s) => new Set(norm(s));
+
+// Jaccard similarity
+const score = (a, b) => {
+  if (!a.size || !b.size) return 0;
+  let inter = 0;
+  for (const t of a) if (b.has(t)) inter++;
+  return inter / (a.size + b.size - inter);
+};
+
+const products = new Map();
+for (const it of crawl) {
+  if (products.has(it.groupId)) continue;
+  let base = it.name;
+  if (it.size && base.endsWith(' ' + it.size)) base = base.slice(0, -(it.size.length + 1));
+  products.set(it.groupId, { groupId: it.groupId, base, category: it.category });
+}
+
+const refTokens = ref.filter((r) => r.en).map((r) => ({ ...r, tk: tokenSet(r.en) }));
+
+const result = [];
+for (const p of products.values()) {
+  const tk = tokenSet(p.base);
+  const scored = refTokens
+    .map((r) => ({ s: +score(tk, r.tk).toFixed(2), en: r.en, ko: r.ko, code: r.code }))
+    .sort((a, b) => b.s - a.s)
+    .slice(0, 3);
+  result.push({ groupId: p.groupId, category: p.category, base: p.base, candidates: scored });
+}
+
+result.sort((a, b) => a.category.localeCompare(b.category) || a.base.localeCompare(b.base));
+writeFileSync(join(outDir, 'kr-match-candidates.json'), JSON.stringify(result, null, 2));
+
+for (const r of result) {
+  console.log(`\n[${r.category}] ${r.base}`);
+  for (const c of r.candidates) console.log(`   ${c.s}  ${(c.en || '').slice(0, 34).padEnd(35)} → ${c.ko}`);
+}
+console.log(`\n총 ${result.length} 제품 → out/kr-match-candidates.json`);

--- a/.claude/skills/crawl-gear/kr-reference.js
+++ b/.claude/skills/crawl-gear/kr-reference.js
@@ -1,0 +1,74 @@
+// Build a Korean-name reference from the official KR importer (seatosummit.co.kr / 니오).
+// For each product: { code, ko (Korean name), en (English model name from detail page) }.
+// Saved to out/seatosummit-kr-ref.json — used to fill nameKorean by English-name matching.
+import { writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+const fetchT = async (u) => {
+  const r = await fetch(u, { headers: { 'User-Agent': UA, 'Accept-Language': 'ko' } });
+  return r.text();
+};
+
+// Leaf categories that bear products and map to our crawl set.
+const CATEGORY_IDS = [
+  33, 34, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+  52, 54, 59, 60, 61, 62, 63, 64, 72, 81, 89, 91, 109, 110, 250,
+];
+
+const listUrl = (id, page) =>
+  `https://www.seatosummit.co.kr/brandsite/index.jsp?BC_ID_pg=${id}&pagename=list&pageNum=${page}`;
+const detailUrl = (code) =>
+  `https://www.seatosummit.co.kr/brandsite/index_list.jsp?BC_ID_pg=0&pagename=content&pageNum=1&p_code=${code}`;
+
+// (p_code, koreanName) pairs from a list page
+const parseList = (html) => {
+  const re = /p_code=([A-Z0-9]+)"\s*\/>\s*<img[^>]*>\s*<div itemprop="text">([^<]+)<\/div>/g;
+  return [...html.matchAll(re)].map((m) => ({ code: m[1], ko: m[2].trim() }));
+};
+
+// English model name from a detail page
+const MODEL_HINT = /(Ether|Comfort|Ultralight|Ascent|Spark|Aeros|Telos|Alto|Ikos|Frontier|Detour|Passage|Pursuit|Camp|Boab|Hamelin|Cinder|Ember|Basecamp|Explore|Amplitude|Alpine|Altitude|Reactor|Adaptor|Expander|Escapist|Evac|Big River|Lightweight|Hydraulic|eVent|eVac|Nano|Mosquito|Sigma|Alpha|Delta|X-|X[- ]?Pot|X[- ]?Mug|X[- ]?Bowl|X[- ]?Plate|X[- ]?Cup|Collapsible|Watercell|Pack Tap|Wilderness|Trek|Tek|DryLite|Airlite|Pocket|Coolmax|Reactor|Thermolite|Premium|Traveller|Deluxe|Vapor|Hydration)[A-Za-z0-9 \-\/\+&'.]{1,55}/g;
+const parseEnglish = (html) => {
+  const m = [...html.matchAll(MODEL_HINT)].map((x) => x[0].trim());
+  return [...new Set(m)][0] ?? '';
+};
+
+const main = async () => {
+  const seen = new Set();
+  const products = [];
+
+  for (const id of CATEGORY_IDS) {
+    for (let page = 1; page <= 20; page++) {
+      let html;
+      try { html = await fetchT(listUrl(id, page)); } catch { break; }
+      const items = parseList(html);
+      const fresh = items.filter((it) => !seen.has(it.code));
+      if (items.length === 0) break;
+      fresh.forEach((it) => { seen.add(it.code); products.push({ ...it, cat: id }); });
+      // stop when a page yields no new codes (end of pagination)
+      if (fresh.length === 0) break;
+    }
+    console.log(`[kr] cat ${id}: total ${products.length}`);
+  }
+
+  console.log(`[kr] fetching English names for ${products.length} products...`);
+  let i = 0;
+  for (const p of products) {
+    i++;
+    if (i % 25 === 0 || i === products.length) console.log(`[kr]   detail ${i}/${products.length}`);
+    try {
+      const d = await fetchT(detailUrl(p.code));
+      p.en = parseEnglish(d);
+    } catch { p.en = ''; }
+  }
+
+  const outPath = join(__dirname, 'out', 'seatosummit-kr-ref.json');
+  writeFileSync(outPath, JSON.stringify(products, null, 2));
+  console.log(`\n[kr] saved ${products.length} products → ${outPath}`);
+  console.log(`[kr] with English name: ${products.filter((p) => p.en).length}`);
+};
+
+main();

--- a/.claude/skills/crawl-gear/sites/sea-to-summit.js
+++ b/.claude/skills/crawl-gear/sites/sea-to-summit.js
@@ -1,0 +1,432 @@
+// Sea to Summit — https://seatosummit.com
+// Shopify site. Uses products.json API for listing + weight (grams field in variants).
+// Spec table in detail pages: <th> row labels, <td> values per variant column.
+// R-Value and temperature info in feature text (not spec table).
+
+const CATEGORY_MAP = {
+  'collections/sleeping-bags': 'sleeping_bag',
+  'collections/down-sleeping-bags': 'sleeping_bag',
+  'collections/mummy-sleeping-bags': 'sleeping_bag',
+  'collections/ultralight-sleeping-bags': 'sleeping_bag',
+  'collections/zero-degree-sleeping-bags': 'sleeping_bag',
+  'collections/backpacking-sleeping-bags': 'sleeping_bag',
+  'collections/synthetic-sleeping-bags': 'sleeping_bag',
+  'collections/quilts': 'sleeping_bag',
+  'collections/sleeping-bag-liners': 'sleeping_bag',
+  'collections/sleeping-pads': 'mat',
+  'collections/air-sprung-cell-sleeping-pads': 'mat',
+  'collections/backpacking-sleeping-pads': 'mat',
+  'collections/camping-sleeping-pads': 'mat',
+  'collections/self-inflating-sleeping-pads': 'mat',
+  'collections/ultralight-sleeping-pads': 'mat',
+  'collections/insulated-sleeping-pads': 'mat',
+  'collections/camping-pillows': 'pillow',
+  'collections/ultralight-backpacking-tents': 'tent',
+  'collections/telos-freestanding-ultralight-tents': 'tent',
+  'collections/tents': 'tent',
+  'collections/camping-tarps': 'tarp',
+  'collections/tent-accessories': 'tent_acc',
+  'collections/camping-cookware': 'cookware_etc',
+  'collections/camping-cups-mugs': 'cup',
+  'collections/camping-bowls': 'bowl',
+  'collections/camping-dinnerware': 'bowl',
+  'collections/camping-plates': 'bowl',
+  'collections/camping-utensils': 'cutlery',
+  'collections/dry-bags': 'pouch',
+  'collections/dry-bag-backpacks': 'pouch',
+  'collections/stuff-sacks': 'pouch',
+  'collections/compression-sacks': 'pouch',
+  'collections/camping-storage': 'pouch',
+  'collections/quick-dry-towels': 'towel',
+  'collections/toiletry-bags': 'pouch',
+  'collections/packing-cubes-travel-organizers': 'pouch',
+};
+
+const guessCategory = (url) => {
+  const keys = Object.keys(CATEGORY_MAP).sort((a, b) => b.length - a.length);
+  for (const key of keys) {
+    if (url.includes(key)) return CATEGORY_MAP[key];
+  }
+  return null;
+};
+
+const slugFromHandle = (handle) => handle.replace(/\//g, '-');
+
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+// Fetch all products from a Shopify collection via products.json (no browser needed)
+const fetchCollectionProducts = async (collectionHandle) => {
+  const results = [];
+  let page = 1;
+  while (true) {
+    const url = `https://seatosummit.com/collections/${collectionHandle}/products.json?limit=250&page=${page}`;
+    try {
+      const res = await fetch(url, { headers: { 'User-Agent': UA } });
+      if (!res.ok) break;
+      const data = await res.json();
+      if (!data.products || data.products.length === 0) break;
+      results.push(...data.products);
+      if (data.products.length < 250) break;
+      page++;
+    } catch (e) {
+      console.log(`[sea-to-summit] products.json fetch failed: ${e.message}`);
+      break;
+    }
+  }
+  return results;
+};
+
+const cleanCell = (cell) => {
+  const metMatch = cell.match(/<span class="met">([\s\S]*?)<\/span>/);
+  return (metMatch ? metMatch[1] : cell)
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#39;/g, "'")
+    .replace(/&times;/g, '×')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
+// Parse spec table. Returns { table: { label: [colVals...] }, headers: [colLabels...] }
+// Columns are per spec-variant (e.g. by size/temp), NOT per products.json variant —
+// a product may have more variants (colours) than spec columns, so callers must map
+// each variant to its column via the header labels.
+const parseSpecTable = (html) => {
+  const table = {};
+  let headers = [];
+  const trBlocks = html.match(/<tr[^>]*>([\s\S]*?)<\/tr>/g) || [];
+  for (const tr of trBlocks) {
+    const cells = tr.match(/<t[hd][^>]*>([\s\S]*?)<\/t[hd]>/g) || [];
+    if (cells.length < 2) continue;
+    const label = cleanCell(cells[0]);
+    const vals = cells.slice(1).map(cleanCell);
+    if (!label) { if (!headers.length) headers = vals; continue; } // header row (empty first cell)
+    table[label] = vals;
+  }
+  return { table, headers };
+};
+
+// Pick the spec column for a variant by matching the column header against the
+// variant's distinguishing option values (size/temp; colour is excluded by caller).
+const normKey = (s) => (s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+const pickColumn = (headers, optionValues) => {
+  const keys = optionValues.map(normKey).filter(Boolean);
+  if (headers.length <= 1) return 0;
+  if (!keys.length) return 0;
+  const idx = headers.findIndex((h) => {
+    const hn = normKey(h);
+    return keys.every((k) => hn.includes(k));
+  });
+  return idx; // -1 if no column matches
+};
+
+const parseWeight = (text) => {
+  // Keep exact metric value (no rounding). "527.1 g27.6 oz" → 527.1
+  const gM = text.match(/(\d+(?:\.\d+)?)\s*g\b/i);
+  if (gM) return parseFloat(gM[1]);
+  const kgM = text.match(/(\d+(?:\.\d+)?)\s*kg\b/i);
+  if (kgM) return parseFloat(kgM[1]) * 1000;
+  const lbOzM = text.match(/(\d+)\s*lb\.?\s+(\d+(?:\.\d+)?)\s*oz/i);
+  if (lbOzM) return parseInt(lbOzM[1]) * 453.592 + parseFloat(lbOzM[2]) * 28.3495;
+  const ozM = text.match(/(\d+(?:\.\d+)?)\s*oz\b/i);
+  if (ozM) return parseFloat(ozM[1]) * 28.3495;
+  return 0;
+};
+
+// Returns { table, headers, specs }. weight/temp are read per-variant in crawlCategory
+// using the matching spec column (headers), since variants ≠ spec columns.
+const fetchDetail = async (handle, category, title = '') => {
+  const empty = { table: {}, headers: [], specs: {} };
+  try {
+    const url = `https://seatosummit.com/products/${handle}`;
+    const res = await fetch(url, { headers: { 'User-Agent': UA } });
+    if (!res.ok) return empty;
+    const html = await res.text();
+
+    const { table, headers } = parseSpecTable(html);
+    const allText = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ');
+    const specs = {};
+
+    // row(label) → first column value helper (for product-wide specs)
+    const cell0 = (label) => (table[label]?.[0] ?? '');
+
+    if (category === 'sleeping_bag') {
+      // Note: comfortTemp/limitTemp/fillWeight are per-variant — set in crawlCategory.
+      if (/goose\s*down|duck\s*down|\d+\s*fill\s*power/i.test(allText)) specs.fillMaterial = 'down';
+      else if (/synthetic|primaloft|thermolite/i.test(allText)) specs.fillMaterial = 'synthetic';
+
+      const fpM = allText.match(/(\d{3})\+?\s*fill[\s-]?power/i);
+      if (fpM) specs.fillPower = parseInt(fpM[1], 10);
+
+      if (/right[\s-]?hand zip|right\s*zip/i.test(allText)) specs.zipperSide = 'right';
+      else if (/left[\s-]?hand zip|left\s*zip/i.test(allText)) specs.zipperSide = 'left';
+
+      if (/quilt/i.test(allText)) specs.shape = 'quilt';
+      else if (/mummy/i.test(allText)) specs.shape = 'mummy';
+      else if (/semi[\s-]?rec|rectangular/i.test(allText)) specs.shape = 'semi-rectangular';
+    }
+
+    if (category === 'mat') {
+      const rvM = allText.match(/R[\s-]?[Vv]alue[\s\S]{0,30}?(\d+(?:\.\d+)?)/);
+      if (rvM) specs.rValue = parseFloat(rvM[1]);
+
+      // Type from product title (page-wide text catches unrelated linked products)
+      const tt = `${title} ${handle}`;
+      if (/self[\s-]?inflat/i.test(tt)) specs.type = 'self-inflating';
+      else if (/\bair\b|air\s*sprung/i.test(tt)) specs.type = 'air';
+      else if (/foam/i.test(tt)) specs.type = 'foam';
+
+      const thM = allText.match(/(\d+(?:\.\d+)?)\s*cm\s*thick/i);
+      if (thM) specs.thickness = parseFloat(thM[1]);
+
+      if (/nylon/i.test(allText)) specs.material = 'nylon';
+    }
+
+    if (category === 'pillow') {
+      if (/down/i.test(allText)) specs.fillMaterial = 'down';
+      else if (/inflat/i.test(allText)) specs.type = 'inflatable';
+      else if (/foam/i.test(allText)) specs.type = 'foam';
+    }
+
+    if (category === 'tent' || category === 'shelter') {
+      const capM = handle.match(/(\d+)[\s-]?person/) ?? allText.match(/(\d+)[\s-]?[Pp]erson/);
+      if (capM) specs.capacity = parseInt(capM[1], 10);
+
+      const poleM = allText.match(/(?:DAC|carbon|aluminum|alloy)\s*(?:pole|featherlight|NFL|NSL)?/i);
+      if (poleM) specs.poleMaterial = poleM[0].trim().slice(0, 80);
+
+      const wpM = allText.match(/(\d{4,5})\s*mm\b/);
+      if (wpM) specs.waterproofRating = parseInt(wpM[1], 10);
+
+      const flyM = allText.match(/(\d+D[\s\w]*nylon|silnylon|sil\/pe|DCF|Dyneema)/i);
+      if (flyM) specs.flyMaterial = flyM[0].trim().slice(0, 80);
+
+      const vestM = cell0('Vestibule Area').match(/(\d+(?:\.\d+)?)\s*m²/);
+      if (vestM) specs.vestibuleArea = parseFloat(vestM[1]);
+
+      if (/double[\s-]?wall/i.test(allText)) specs.wallStructure = 'double';
+      else if (/single[\s-]?wall/i.test(allText)) specs.wallStructure = 'single';
+    }
+
+    if (category === 'tarp') {
+      const wpM = allText.match(/(\d{4,5})\s*mm\b/);
+      if (wpM) specs.waterproofRating = parseInt(wpM[1], 10);
+      const matM = allText.match(/(\d+D[\s\w]*nylon|silnylon|sil\/pe|DCF|ultra[\s-]?sil)/i);
+      if (matM) specs.material = matM[0].trim().slice(0, 80);
+    }
+
+    if (category === 'cup' || category === 'bowl' || category === 'cookware_etc') {
+      if (/titanium/i.test(allText)) specs.material = 'titanium';
+      else if (/aluminum/i.test(allText)) specs.material = 'aluminum';
+      else if (/stainless/i.test(allText)) specs.material = 'stainless';
+      else if (/polypropylene|plastic|BPA/i.test(allText)) specs.material = 'polypropylene';
+
+      const capRaw = cell0('Capacity') || cell0('Volume');
+      const capM = capRaw.match(/(\d+(?:\.\d+)?)\s*[mM][lL]/) ??
+                   capRaw.match(/(\d+(?:\.\d+)?)\s*[lL]\b/) ??
+                   handle.match(/(\d+)(?:ml|l)\b/i);
+      if (capM) {
+        const v = parseFloat(capM[1]);
+        specs.capacity = /[lL]\b/.test(capM[0]) && v < 10 ? Math.round(v * 1000) : Math.round(v);
+      }
+
+      if (/set\b|cook[\s-]?set/i.test(handle) || /set\b|cook[\s-]?set/i.test(allText.slice(0, 500))) specs.isSet = true;
+      if (/insulated|double[\s-]?wall/i.test(allText)) specs.isInsulated = true;
+    }
+
+    if (category === 'cutlery') {
+      if (/titanium/i.test(allText)) specs.material = 'titanium';
+      else if (/aluminum/i.test(allText)) specs.material = 'aluminum';
+      else if (/stainless/i.test(allText)) specs.material = 'stainless';
+      if (/set\b|3[\s-]piece|4[\s-]piece/i.test(handle)) specs.isSet = true;
+    }
+
+    if (category === 'pouch') {
+      if (/ultra[\s-]?sil|silnylon|nylon/i.test(allText)) specs.material = 'nylon';
+      if (/waterproof|dry\s*bag|dry\s*sack/i.test(allText)) specs.isWaterproof = true;
+      const volM = (cell0('Volume') || cell0('Capacity')).match(/(\d+(?:\.\d+)?)\s*[lL]\b/) ??
+                   handle.match(/(\d+)[lL]\b/i);
+      if (volM) specs.capacity = Math.round(parseFloat(volM[1]) * 1000);
+    }
+
+    if (category === 'towel') {
+      if (/microfibre|microfiber/i.test(allText)) specs.material = 'microfiber';
+      else if (/cotton/i.test(allText)) specs.material = 'cotton';
+    }
+
+    return { table, headers, specs };
+  } catch (e) {
+    return empty;
+  }
+};
+
+const parseTempC = (text) => {
+  const m = text.match(/(-?\d+)\s*°C/);
+  return m ? parseInt(m[1], 10) : null;
+};
+
+const crawlCategory = async (browser, categoryUrl, { withWeight = true } = {}) => {
+  const handleM = categoryUrl.match(/collections\/([^/?#]+)/);
+  if (!handleM) return [];
+  const collectionHandle = handleM[1];
+  const category = guessCategory(categoryUrl) ?? 'etc';
+
+  console.log(`[sea-to-summit] fetching collection: ${collectionHandle}`);
+  const products = await fetchCollectionProducts(collectionHandle);
+  console.log(`[sea-to-summit] ${products.length} products found`);
+
+  const results = [];
+  let idx = 0;
+  for (const product of products) {
+    idx++;
+    if (idx === 1 || idx % 20 === 0 || idx === products.length) {
+      console.log(`[sea-to-summit]   detail ${idx}/${products.length}`);
+    }
+
+    // Get image from first product image
+    let baseImageUrl = product.images?.[0]?.src ?? '';
+    if (baseImageUrl.startsWith('//')) baseImageUrl = 'https:' + baseImageUrl;
+    baseImageUrl = baseImageUrl.split('?')[0];
+
+    // Option name → field mapping
+    const optionNames = (product.options ?? []).map((o) => o.name.toLowerCase());
+    const colorOptIdx = optionNames.findIndex((n) => /colou?r/.test(n));
+    const sizeOptIdx  = optionNames.findIndex((n) => /size/.test(n));
+
+    let baseSpecs = {};
+    let table = {};
+    let headers = [];
+    if (withWeight) {
+      const detail = await fetchDetail(product.handle, category, product.title);
+      baseSpecs = detail.specs;
+      table = detail.table;
+      headers = detail.headers;
+    }
+    // weight row: prefer Packed Weight, then Weight, then Set Weight
+    const weightRow = table['Packed Weight'] ?? table['Weight'] ?? table['Set Weight'] ?? [];
+
+    // One entry per variant
+    const variants = product.variants ?? [];
+    variants.forEach((variant, vi) => {
+      const color = colorOptIdx >= 0 ? (variant[`option${colorOptIdx + 1}`] ?? '') : '';
+
+      // "One Size" / "Default Title" mean there is no real size choice → treat as blank.
+      const noSize = (v) => !v || /^(one size|default title|default)$/i.test(String(v).trim());
+      const size = sizeOptIdx >= 0 && !noSize(variant[`option${sizeOptIdx + 1}`])
+        ? variant[`option${sizeOptIdx + 1}`] : '';
+
+      // Combine non-color, non-size options into size label (e.g. "Temp Rating")
+      const extraOpts = optionNames
+        .map((n, i) => (i !== colorOptIdx && i !== sizeOptIdx && !noSize(variant[`option${i + 1}`]) ? variant[`option${i + 1}`] : null))
+        .filter(Boolean);
+      const sizeLabel = [size, ...extraOpts].filter(Boolean).join(' / ');
+
+      // Map this variant to its spec column by header (colour is excluded — spec
+      // tables don't vary by colour). Fall back to positional index.
+      const nonColorVals = optionNames
+        .map((n, i) => (i !== colorOptIdx ? variant[`option${i + 1}`] : null))
+        .filter(Boolean);
+      let col = pickColumn(headers, nonColorVals);
+      if (col < 0) col = headers.length === weightRow.length ? -1 : vi; // -1 → unknown, leave 0
+      const colIdx = col;
+
+      const weight = colIdx >= 0 ? parseWeight(weightRow[colIdx] ?? '') : 0;
+
+      // Per-variant specs: clone common specs, then fill variant-specific columns.
+      const specs = { ...baseSpecs };
+      if (category === 'sleeping_bag' && colIdx >= 0) {
+        const lower = parseTempC((table['Temperature Rating (ISO Lower)'] ?? table['Temperature Rating'] ?? [])[colIdx] ?? '');
+        if (lower !== null) specs.limitTemp = lower;
+        const comfort = parseTempC((table["Women's Temperature Rating (ISO Comfort)"] ?? table['Temperature Rating (ISO Comfort)'] ?? [])[colIdx] ?? '');
+        if (comfort !== null) specs.comfortTemp = comfort;
+        const fwM = ((table['Fill Weight'] ?? [])[colIdx] ?? '').match(/(\d+)\s*g/);
+        if (fwM) specs.fillWeight = parseInt(fwM[1], 10);
+      }
+
+      // Per-variant (per-colour) image: collection products.json puts it on
+      // variant.featured_image; individual product.json uses variant.image_id.
+      let imageUrl = baseImageUrl;
+      if (variant.featured_image?.src) {
+        imageUrl = variant.featured_image.src.split('?')[0];
+      } else if (variant.image_id) {
+        const img = product.images?.find((im) => im.id === variant.image_id);
+        if (img) imageUrl = img.src.split('?')[0];
+      }
+
+      results.push({
+        groupId: `sea-to-summit_${slugFromHandle(product.handle)}`,
+        category,
+        company: 'sea-to-summit',
+        companyKorean: '씨투써밋',
+        name: sizeLabel ? `${product.title} ${sizeLabel}` : product.title,
+        nameKorean: '',
+        color,
+        colorKorean: '',
+        size: sizeLabel,
+        sizeKorean: '',
+        weight,
+        imageUrl,
+        specs,
+        _source: categoryUrl,
+      });
+    });
+  }
+  return results;
+};
+
+export default {
+  name: 'sea-to-summit',
+  company: 'sea-to-summit',
+  baseUrl: 'https://seatosummit.com',
+  defaultCategories: [
+    'https://seatosummit.com/collections/sleeping-bags',
+    'https://seatosummit.com/collections/sleeping-pads',
+    'https://seatosummit.com/collections/camping-pillows',
+    'https://seatosummit.com/collections/ultralight-backpacking-tents',
+    'https://seatosummit.com/collections/camping-tarps',
+    'https://seatosummit.com/collections/tent-accessories',
+    'https://seatosummit.com/collections/camping-cookware',
+    'https://seatosummit.com/collections/camping-cups-mugs',
+    'https://seatosummit.com/collections/camping-bowls',
+    'https://seatosummit.com/collections/camping-utensils',
+    'https://seatosummit.com/collections/dry-bags',
+    'https://seatosummit.com/collections/stuff-sacks',
+    'https://seatosummit.com/collections/quick-dry-towels',
+  ],
+  crawl: async (browser, { categoryUrls, withWeight = true } = {}) => {
+    const urls = categoryUrls?.length ? categoryUrls : [
+      'https://seatosummit.com/collections/sleeping-bags',
+      'https://seatosummit.com/collections/sleeping-pads',
+      'https://seatosummit.com/collections/camping-pillows',
+      'https://seatosummit.com/collections/ultralight-backpacking-tents',
+      'https://seatosummit.com/collections/camping-tarps',
+      'https://seatosummit.com/collections/tent-accessories',
+      'https://seatosummit.com/collections/camping-cookware',
+      'https://seatosummit.com/collections/camping-cups-mugs',
+      'https://seatosummit.com/collections/camping-bowls',
+      'https://seatosummit.com/collections/camping-utensils',
+      'https://seatosummit.com/collections/dry-bags',
+      'https://seatosummit.com/collections/stuff-sacks',
+      'https://seatosummit.com/collections/quick-dry-towels',
+    ];
+    const all = [];
+    for (const url of urls) {
+      console.log(`[sea-to-summit] crawling ${url}`);
+      try {
+        const items = await crawlCategory(browser, url, { withWeight });
+        console.log(`[sea-to-summit] ${items.length} items from ${url}`);
+        all.push(...items);
+      } catch (e) {
+        console.log(`[sea-to-summit] error on ${url}: ${e.message} — skipping`);
+      }
+    }
+    // Deduplicate by groupId+size+color (same variant may appear in multiple collections)
+    const seen = new Set();
+    return all.filter((item) => {
+      const key = `${item.groupId}|${item.size}|${item.color}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  },
+};


### PR DESCRIPTION
## 개요
crawl-gear 스킬 업데이트 — Sea to Summit 어댑터 개선 + 한글명 파이프라인. **크롤 중간 산출물(out/) 없이 스킬 파일만** 포함.

## 변경 (5개 파일)
- **`sites/sea-to-summit.js`** — 변형 단위 수집, 스펙 컬럼 헤더 매칭(무게/온도 정렬), Set Weight, 무게 반올림 제거, 색상별 이미지(featured_image), One Size→빈값
- **`kr-reference.js` / `kr-match.js` / `kr-apply.js`** — 한글명 파이프라인 (KR 수입사 레퍼런스, 변형 단위 매칭, sizeKorean/colorKorean)
- **`SKILL.md`** — 위 룰 문서화 + Node 20 푸시 주의 + 강차단 사이트 한계

## 참고
- 기존 PR #4(`crawl/sea-to-summit-adapter`)는 out/ 중간 산출물 80개 + .gitignore 제거가 섞여 있어, 이 깨끗한 브랜치로 대체합니다. PR #4는 닫아도 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)