### PR TITLE
코베아(Kovea) 크롤 어댑터 + 이미지 OCR 스펙 파이프라인 (317개)

### DIFF
--- a/.claude/skills/crawl-gear/SKILL.md
+++ b/.claude/skills/crawl-gear/SKILL.md
@@ -117,6 +117,7 @@ HTML 카드 그리드에서 확인:
 | **자체 SPA** | React/Vue 빌드 | 사이트별 다름 — 일회성 DOM 덤프 필요 |
 | **SPA + POST 리스팅 API** (몽벨 케이스) | 카테고리 링크가 전부 같은 경로(예: `/products/list`)에 `?c=N` 쿼리로만 구분, 리스팅이 빈 DOM | fetch 인터셉트(`window.fetch` 래핑 후 더보기 클릭)로 XHR 찾기 → POST 엔드포인트(예: `/products/more?c=N` body `{o:offset,l:limit}`)가 **색상·사이즈·무게 포함 구조화 JSON** 반환. 브라우저 same-origin fetch에 `meta[name=csrf-token]` 얹어 호출 |
 | **한국형 PHP 쇼핑몰** (youngcart/cafe24, KR 한글명 레퍼런스용) | `list.php?ca_id=`, `item.php?it_id=`, gnuboard 흔적 | 서버렌더라 node fetch 직접 가능(봇차단 적음), 페이지네이션 `&page=N`. `<div class="model">코드</div><div class="name">한글명</div>` 패턴 |
+| **Cafe24 + 스펙이 이미지** (코베아 케이스) | `cafe24`, `/product/<slug>/<no>/`, 상세 스펙이 텍스트 아닌 **긴 이미지**(koveaimage CDN / `/web/upload/NNEditor`) | 리스팅·이름(og:title)·옵션은 fetch, **스펙·무게·온도·색상은 macOS Vision OCR**(타일 분할). 전체 제품은 `/sitemap.xml`. 아래 "스펙이 이미지 안에 있을 때" 참고 |
 
 ### 자주 마주치는 문제 + 해결책
 
@@ -378,8 +379,9 @@ etc
 
 1. **Node 의존성** — 레포 루트에서 `npm install` (이미 `package.json` 에 `puppeteer`, `firebase-admin` 선언됨). 워크트리면 글로벌 규칙대로 메인 클론 `node_modules` 를 심링크.
    - **Node 버전 주의:** 크롤(`crawl.js`)은 최신 Node 무방하지만, **Firestore push(firebase-admin)는 Node 20 LTS 로 실행**해야 한다. Node 22+(특히 26)에선 firebase-admin 의 전이 의존성이 제거된 `SlowBuffer` 를 참조해 크래시한다. 푸시만 `node@20` 바이너리로: `/opt/homebrew/opt/node@20/bin/node server.js`.
-2. **Pillow (선택)** — `nemo-specs.py` / `nemo-findtable.py`(한국 고시 이미지 크롭) 사용 시에만. `python3 -m pip install Pillow`. 글로벌 사이트 스크래퍼(`*-global.py`)는 표준 라이브러리만 쓰므로 불필요.
-3. **serviceAccountKey.json** — Firestore push 시점에만 (아래). 머신마다 수동 추가.
+2. **Pillow (선택)** — `nemo-specs.py` / `nemo-findtable.py`(한국 고시 이미지 크롭), 코베아 OCR 스크립트의 이미지 타일링에 사용. `python3 -m pip install Pillow`. 글로벌 사이트 스크래퍼(`*-global.py`)는 표준 라이브러리만 쓰므로 불필요.
+3. **pyobjc (선택)** — 스펙이 이미지 안에 있는 사이트(코베아 등) OCR 시에만. `python3 -m pip install pyobjc-framework-Vision pyobjc-framework-Quartz`. macOS Vision 한국어 OCR(`ocr.py`, `kovea-*.py`)에 필요. (swift 직접 컴파일은 베타 SDK 충돌로 실패할 수 있음 → pyobjc 사용)
+4. **serviceAccountKey.json** — Firestore push 시점에만 (아래). 머신마다 수동 추가.
 
 `.config.local.json`(adminUid) 은 gitignore 라 동기화 안 되지만, serviceAccountKey 만 있으면 첫 실행 시 Firestore 에서 자동 감지·저장된다.
 
@@ -430,3 +432,31 @@ S2S처럼 KR 수입사 상세에 **영문 모델명**이 있으면 영문-토큰
 3. **매칭** (`kr-apply-montbell.js`): 음역결과 ↔ KR 한글명을 **숫자집합 완전일치 + 성별 일치 + bigram Dice ≥ 0.85(근접 길이 우선)** 로 매칭. 매칭되면 KR 공식명 verbatim, 아니면 음역 폴백.
    - **반드시 가드**: ① 성별(Men's↔남 / Women's↔여) — 없으면 여성 제품에 남성 이름이 박힘. ② KR 시장 프리픽스(`US`/`PS`/`WIC`/`SIC`)·말미 영문색상 제거. ③ 숫자집합은 *정확히* 일치(부분집합 X) — `30L`↔`30L 2`(버전), `20L`↔`30L` 오매칭 방지.
    - 팩 카테고리는 KR 관례상 용량에 `L` 부착(차차 팩 30 → 30L)해 패밀리 내 표기 통일.
+
+### 스펙이 이미지 안에 있을 때 — macOS Vision OCR (코베아 세션에서 확립)
+
+국내 브랜드(코베아 등)는 무게·크기·재질이 **본문 텍스트가 아니라 긴 상세 이미지** 안에 있다. 한국 표준 "상품 정보 제공 고시" 표(크기/중량/재질/수용인원/내수압)가 이미지 하단에, 일부는 영문 "Specification" 표가 들어있다. 도구·스크립트: `ocr.py`(범용 Vision OCR), `kovea-specs.py`(고시/Spec 파싱), `kovea-fixweight.py`(위치기반 무게/내하중), `kovea-sleeptemp.py`(침낭 온도), `kovea-imgcolor.py`(이미지 색상항목), `kovea-options.py`(옵션 변형), `kovea-sitemap-add.js`(사이트맵 전체 제품).
+
+**OCR (`ocr.py`):**
+- pyobjc로 macOS Vision 사용 (`pip install pyobjc-framework-Vision pyobjc-framework-Quartz`). swift는 베타 SDK 충돌로 막힐 수 있어 pyobjc가 안전.
+- **한국어(ko-KR)는 이 머신에서 fast 레벨(0)에서만 지원** — accurate(1)는 라틴 전용. `setRevision_(3)` + `setRecognitionLevel_(0)`.
+- **긴 이미지(900×20000px 등)는 Vision이 다운샘플해 글자가 깨진다 → 반드시 ~1500px 타일로 잘라 OCR.** 직접 통짜 OCR 금지.
+- 바운딩박스(x,y)를 주므로 **라벨↔값을 같은 행(y)으로 정렬** 가능 — 세로 컬럼 레이아웃(라벨열/값열 분리: `규격/중량/내하중` → `…/1.45kg/120kg`)에서 필수. 텍스트만으로 파싱하면 중량 옆에 온 내하중 값을 무게로 오인한다.
+
+**무게/스펙 파싱 함정 (실제 겪음):**
+- 셀 "중량 : 970 / 내하중 : 30kg" → 단위 없는 970(=970g)을 건너뛰고 30kg(내하중)을 무게로 잡음. **라벨별로 sub-값을 분리**하고, 단위 없는 숫자는 `<50 ⇒ kg, 그외 ⇒ g`로 추정.
+- 고시 표는 **마지막 상세 이미지 하단**에 있는 경우가 대부분이나 부속 이미지가 뒤에 붙으면 끝에서 2~3번째에 있다 → 마지막 3장 스캔.
+- 침낭 온도는 하단 고시가 아니라 **이미지 중간**에 ISO 23537 표("Comfort 15°C~0°C / Lower Limit") 또는 3단계 "N°C / °F"(쾌적/숙면/극한)로 있다. **세탁 온도(물 30°C)는 `/°F` 페어 조건으로 제외**.
+
+**색상 — 3소스 결합:**
+1. 이름의 **`[그레이]` 대괄호** 또는 `(블루)` 소괄호 (색상 키워드일 때만; 메쉬/하드탑/M 등 변형어는 제외)
+2. 이미지 **"색상" 항목** OCR (단일 색상만 채택, "Moss / Black"처럼 복수 선택지는 비움). 영문→한글 변환(Sand→샌드).
+3. **Cafe24 옵션 셀렉트** → 옵션마다 개별 제품 행(같은 groupId, 색상/사이즈 다름). **색상·사이즈 옵션만 확장** — "기타" 옵션(폴 길이·모델호환)까지 cartesian 하면 수천 행 폭발. `[A/S SHOP]` 스페어부품은 제외.
+
+**완전 수집 — 사이트맵:** 카테고리 리스팅은 품절·단종을 누락한다. `/sitemap.xml`이 전체 제품(품절 포함)을 담으므로 마스터로 쓰고, 사이트맵엔 카테고리가 없으니 **제품명 키워드로 분류**(국내 브랜드는 이름에 종류 명시). 단 브레드크럼은 유입경로(리퍼존/기획전)라 카테고리로 못 씀.
+
+**데이터 미존재 구분:** 무게 0이 추출 버그인지 데이터 부재인지 — 표본 OCR로 이미지에 중량 표기가 아예 없으면 사이트에 데이터가 없는 것(액세서리·신상 다수). 어댑터로 해결 불가.
+
+### Firestore push 시 _source 주의 (코베아/몽벨 공통)
+
+`push.js`는 비대화형에서 **`_source`별로 카테고리를 일괄 적용**한다(그 source 첫 항목의 category). 한 source에 여러 카테고리가 섞이면(예: 몽벨 c=34=침낭+매트, 코베아 sitemap source) 전부 한 카테고리로 덮인다 → **push 전에 `_source = 'brand_' + category`로 정리**해 source-카테고리를 1:1로 맞춘다. push는 `node@20 push.js <json>` (firebase-admin은 Node 20 필요).

--- a/.claude/skills/crawl-gear/kovea-fixnames.js
+++ b/.claude/skills/crawl-gear/kovea-fixnames.js
@@ -1,0 +1,72 @@
+// Retrofit name/size on an existing Kovea crawl JSON without re-crawling or re-OCR.
+// Fixes: (1) English `name` wrongly filled with Korean → emptied;
+//        (2) `nameKorean` from URL slug (drops '.', '~') → real og:title;
+//        (3) trailing size token in name (e.g. "가죽 테이블보 M") → size/sizeKorean.
+// Specs/weight/imageUrl already on the JSON are preserved.
+// Usage: node kovea-fixnames.js <spec-json> [out-json]
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+const BASE = 'https://www.kovea.co.kr';
+const SIZE_KO = { XS: '엑스스몰', S: '스몰', M: '미디엄', L: '라지', XL: '엑스라지', XXL: '투엑스라지', '2XL': '투엑스라지', '3XL': '쓰리엑스라지' };
+
+const fetchName = async (no) => {
+  try {
+    const r = await fetch(`${BASE}/product/x/${no}/`, { headers: { 'User-Agent': UA } });
+    const h = await r.text();
+    const m = h.match(/<meta[^>]*property=["']og:title["'][^>]*content=["']([^"']+)["']/i)
+      || h.match(/content=["']([^"']+)["'][^>]*property=["']og:title["']/i);
+    return m ? m[1].replace(/\s*-\s*코베아\s*$/, '').replace(/\s+/g, ' ').trim() : '';
+  } catch { return ''; }
+};
+// Korean colour keywords (Kovea bakes colour into the name, often in trailing "(...)").
+const COLOR_KW = ['다크그레이', '라이트그레이', '그레이지', '그레이', '차콜', '블랙', '화이트', '아이보리',
+  '카키그린', '카키', '카모', '다크네이비', '네이비', '세이지', '올리브', '포레스트', '그린',
+  '스카이블루', '블루', '레드', '오렌지', '옐로우', '머스타드', '다크브라운', '브라운', '코요테',
+  '모카', '크림', '샌드', '탄', '베이지', '핑크', '퍼플', '라벤더', '버건디', '와인', '골드', '실버', '민트', '코랄'];
+const findColor = (s) => COLOR_KW.find((c) => s === c || s.includes(c)) || '';
+
+// Returns {color, size}. Colour: trailing "(...)" or a trailing known colour word.
+// Size: a trailing S/M/L/… token after the colour part is removed.
+const extractVariant = (name) => {
+  let color = '';
+  let base = name;
+  const paren = name.match(/\(([^)]+)\)\s*$/);
+  if (paren) {
+    const c = findColor(paren[1].trim());
+    if (c) { color = paren[1].trim(); base = name.replace(/\s*\([^)]*\)\s*$/, '').trim(); }
+  }
+  if (!color) {
+    const last = base.split(/\s+/).pop();
+    if (last && findColor(last) === last) { color = last; base = base.replace(/\s+\S+$/, '').trim(); }
+  }
+  const sm = base.match(/\s(XS|S|M|L|XL|XXL|2XL|3XL)$/i);
+  const size = sm ? sm[1].toUpperCase() : '';
+  return { color, size };
+};
+
+const main = async () => {
+  const path = process.argv[2];
+  const out = process.argv[3] || path;
+  const data = JSON.parse(readFileSync(path, 'utf8'));
+  let fixed = 0, sized = 0, colored = 0;
+  for (let i = 0; i < data.length; i++) {
+    const it = data[i];
+    const no = it._productNo || (it.groupId || '').replace('kovea_', '');
+    const real = await fetchName(no);
+    if (real) { it.nameKorean = real; fixed++; }
+    it.name = ''; // English name not available for this Korean brand
+    const { color, size } = extractVariant(it.nameKorean);
+    it.size = size;
+    it.sizeKorean = size ? (SIZE_KO[size] || size) : '';
+    it.color = '';
+    it.colorKorean = color;
+    if (size) sized++;
+    if (color) colored++;
+    if ((i + 1) % 20 === 0 || i + 1 === data.length) console.log(`[fixnames] ${i + 1}/${data.length} (name ${fixed}, size ${sized}, color ${colored})`);
+  }
+  writeFileSync(out, JSON.stringify(data, null, 2));
+  console.log(`\n저장: ${out}  (이름보정 ${fixed}, 사이즈 ${sized}, 색상 ${colored})`);
+};
+
+main();

--- a/.claude/skills/crawl-gear/kovea-fixweight.py
+++ b/.claude/skills/crawl-gear/kovea-fixweight.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# Re-extract weight + maxLoad from the 고시 table using POSITIONAL OCR so the value is
+# matched to its label by table ROW. The flat-text parser mis-handles the column layout
+# (labels stacked: 규격/중량/내하중/재질, values stacked: …/1.45kg/120kg/…) and grabbed
+# the 내하중 (max-load) value as weight. Row alignment (label & value share y) fixes it.
+# Usage: python3 kovea-fixweight.py <json> [out-json] [cat1,cat2,...]
+import json
+import re
+import sys
+from io import BytesIO
+
+import Vision
+import Quartz
+import urllib.parse
+import urllib.request
+from PIL import Image
+
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36"
+REFERER = "https://www.kovea.co.kr/"
+BOTTOM_PX = 7000
+TILE_H = 1500
+OVERLAP = 160
+
+
+def http_get(url):
+    safe = urllib.parse.quote(url, safe=":/?=&%")
+    req = urllib.request.Request(safe, headers={"User-Agent": UA, "Referer": REFERER})
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return r.read()
+
+
+def load_image(url):
+    return Image.open(BytesIO(http_get(url))).convert("RGB")
+
+
+def ocr_pos(im):
+    """OCR → [(text, x, y_top)] normalized within `im`."""
+    bio = BytesIO()
+    im.save(bio, format="PNG")
+    data = bio.getvalue()
+    src = Quartz.CGImageSourceCreateWithData(data, None)
+    cg = Quartz.CGImageSourceCreateImageAtIndex(src, 0, None)
+    req = Vision.VNRecognizeTextRequest.alloc().init()
+    req.setRevision_(3)
+    req.setRecognitionLevel_(0)
+    req.setUsesLanguageCorrection_(False)
+    req.setRecognitionLanguages_(["ko-KR", "en-US"])
+    h = Vision.VNImageRequestHandler.alloc().initWithCGImage_options_(cg, None)
+    h.performRequests_error_([req], None)
+    out = []
+    for o in (req.results() or []):
+        c = o.topCandidates_(1)
+        if not c:
+            continue
+        bb = o.boundingBox()
+        out.append((c[0].string(), float(bb.origin.x), float(1.0 - (bb.origin.y + bb.size.height))))
+    return out
+
+
+def cells_of(im):
+    """Positional OCR over the bottom band → [(y_px, x, text)] sorted top→bottom."""
+    w, h = im.size
+    band = im.crop((0, max(0, h - BOTTOM_PX), w, h))
+    bw, bh = band.size
+    cells = []
+    y = 0
+    while y < bh:
+        tile = band.crop((0, y, bw, min(bh, y + TILE_H)))
+        th = tile.size[1]
+        for (txt, cx, cy) in ocr_pos(tile):
+            cells.append((y + cy * th, cx, txt.strip()))
+        y += TILE_H - OVERLAP
+    cells.sort()
+    return cells
+
+
+def row_value(cells, idx, pattern):
+    """Find a value matching `pattern` on the same row as cells[idx] (then nearest below)."""
+    y0 = cells[idx][0]
+    x0 = cells[idx][1]
+    # same-row candidates (within ~22px), prefer to the right of the label
+    same = [(c[1], c[2]) for c in cells if abs(c[0] - y0) <= 22]
+    same.sort()
+    for x, txt in same:
+        if x <= x0 - 0.01:
+            continue
+        m = re.search(pattern, txt, re.I)
+        if m:
+            return m
+    # fallback: any same-row cell
+    for x, txt in same:
+        m = re.search(pattern, txt, re.I)
+        if m:
+            return m
+    return None
+
+
+WEIGHT_RE = r"(\d+(?:\.\d+)?)\s*(kg|g)\b"
+LOAD_RE = r"(\d[\d,]*)\s*kg"
+LABELS = r"내하중|최대하중|정하중|허용하중|재질|규격|크기|구성|색상|시트|프레임|원단"
+
+
+def weight_from_text(txt):
+    """Weight from a cell that may also hold other labels, e.g.
+    "중량 : 970 / 내하중 : 30kg" → 970 g (NOT the 30kg load)."""
+    i = txt.find("중량")
+    if i < 0:
+        i = txt.find("무게")
+    if i < 0:
+        return None
+    seg = re.split(LABELS, txt[i + 2:])[0]  # stop before the next label (e.g. 내하중)
+    m = re.search(r"(\d+(?:\.\d+)?)\s*(kg|g)?", seg)  # require a real number, not a stray '.'
+    if not m:
+        return None
+    v = float(m.group(1))
+    unit = m.group(2)
+    if unit:
+        g = v * 1000 if unit.lower() == "kg" else v
+    else:
+        g = v * 1000 if v < 50 else v  # bare number: <50 ⇒ kg (1.45/16), else g (970/1450)
+    return int(round(g))
+
+
+def load_from_text(txt):
+    for lab in ("내하중", "최대하중", "정하중", "허용하중", "최대정하중"):
+        i = txt.find(lab)
+        if i >= 0:
+            seg = re.split(r"중량|무게|재질|규격|크기|구성", txt[i + len(lab):])[0]
+            m = re.search(LOAD_RE, seg)
+            if m:
+                return int(m.group(1).replace(",", ""))
+    return None
+
+
+def extract(cells):
+    res = {}
+    # Pass 1 — in-cell values (label and value in the same OCR cell). Most reliable, and
+    # isolates the 중량 sub-value so a neighbouring 내하중 can't hijack it.
+    for (y, x, txt) in cells:
+        if "weight" not in res and re.search(r"중량|무게", txt):
+            w = weight_from_text(txt)
+            if w is not None:
+                res["weight"] = w
+        if "maxLoad" not in res and re.search(r"내하중|최대하중|정하중|허용하중|최대정하중", txt):
+            l = load_from_text(txt)
+            if l is not None:
+                res["maxLoad"] = l
+    # Pass 2 — column layout: bare label cell, value in the same table row.
+    for i, (y, x, txt) in enumerate(cells):
+        if "weight" not in res and re.search(r"^\s*(중량|무게)\s*$", txt):
+            m = row_value(cells, i, WEIGHT_RE)
+            if m:
+                v = float(m.group(1))
+                res["weight"] = int(round(v * 1000)) if m.group(2).lower() == "kg" else int(round(v))
+        if "maxLoad" not in res and re.search(r"^\s*(내하중|최대하중|정하중|허용하중)\s*$", txt):
+            m = row_value(cells, i, LOAD_RE)
+            if m:
+                res["maxLoad"] = int(m.group(1).replace(",", ""))
+    return res
+
+
+def main():
+    path = sys.argv[1]
+    out = sys.argv[2] if len(sys.argv) > 2 else path
+    cats = set((sys.argv[3].split(",") if len(sys.argv) > 3 else ["chair", "table", "tent"]))
+    data = json.load(open(path))
+    targets = [x for x in data if x.get("category") in cats and (x.get("_specImages") or [])]
+    fixed_w = fixed_l = 0
+    for i, item in enumerate(targets, 1):
+        try:
+            # the 고시 with 중량 may sit in the last image's bottom, or an earlier one
+            # (e.g. air tents with trailing accessory images) — scan the last 3.
+            ex = {}
+            for url in reversed(item["_specImages"][-3:]):
+                cells = cells_of(load_image(url))
+                ex = extract(cells)
+                if "weight" in ex or "maxLoad" in ex:
+                    break
+            note = []
+            if "weight" in ex and ex["weight"] != item.get("weight"):
+                note.append(f"w {item.get('weight')}→{ex['weight']}")
+                item["weight"] = ex["weight"]
+                fixed_w += 1
+            if "maxLoad" in ex:
+                if item.setdefault("specs", {}).get("maxLoad") != ex["maxLoad"]:
+                    fixed_l += 1
+                item["specs"]["maxLoad"] = ex["maxLoad"]
+            if note:
+                print(f"  [{i}/{len(targets)}] {item['nameKorean'][:24]}  {'; '.join(note)} | load {ex.get('maxLoad','-')}")
+        except Exception as e:
+            print(f"  err {item.get('groupId')}: {e}")
+    json.dump(data, open(out, "w"), ensure_ascii=False, indent=2)
+    print(f"\n저장: {out}  (weight 수정 {fixed_w}, maxLoad 채움/수정 {fixed_l})")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/crawl-gear/kovea-imgcolor.py
+++ b/.claude/skills/crawl-gear/kovea-imgcolor.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Fill colorKorean from the image spec's "색상" row for products whose name has no colour.
+# Single colour (e.g. "Sand", "Light Blue") → translated to Korean. Multiple options
+# (e.g. "Moss, Black") are left blank — that listing isn't a single colour variant.
+# Usage: python3 kovea-imgcolor.py <json> [out]
+import json
+import re
+import sys
+import importlib.util
+
+_fw = importlib.util.spec_from_file_location("fw", __file__.replace("kovea-imgcolor.py", "kovea-fixweight.py"))
+fw = importlib.util.module_from_spec(_fw)
+_fw.loader.exec_module(fw)
+
+EN_KO = [
+    ("light gray", "라이트그레이"), ("light grey", "라이트그레이"), ("dark gray", "다크그레이"),
+    ("light blue", "라이트블루"), ("sky blue", "스카이블루"), ("dark navy", "다크네이비"),
+    ("moss green", "모스그린"), ("khaki green", "카키그린"), ("dark brown", "다크브라운"),
+    ("black", "블랙"), ("white", "화이트"), ("ivory", "아이보리"), ("gray", "그레이"), ("grey", "그레이"),
+    ("navy", "네이비"), ("khaki", "카키"), ("sand", "샌드"), ("tan", "탄"), ("brown", "브라운"),
+    ("moss", "모스그린"), ("olive", "올리브"), ("forest", "포레스트"), ("green", "그린"),
+    ("blue", "블루"), ("red", "레드"), ("orange", "오렌지"), ("yellow", "옐로우"), ("pink", "핑크"),
+    ("purple", "퍼플"), ("beige", "베이지"), ("charcoal", "차콜"), ("coyote", "코요테"),
+    ("mustard", "머스타드"), ("burgundy", "버건디"), ("wine", "와인"), ("gold", "골드"),
+    ("silver", "실버"), ("mint", "민트"), ("coral", "코랄"), ("cream", "크림"), ("vanilla", "바닐라"),
+    ("flint", "플린트"),
+]
+KO_COLORS = ["다크그레이", "라이트그레이", "그레이", "차콜", "블랙", "화이트", "아이보리", "카키그린",
+             "카키", "네이비", "세이지", "올리브", "포레스트", "모스그린", "그린", "스카이블루", "블루",
+             "레드", "오렌지", "옐로우", "브라운", "코요테", "샌드", "탄", "바닐라", "베이지", "핑크",
+             "퍼플", "버건디", "와인", "골드", "실버", "민트", "코랄", "플린트"]
+
+
+def to_korean(val):
+    v = val.strip().lower()
+    for en, ko in EN_KO:
+        if v == en:
+            return ko
+    for ko in KO_COLORS:
+        if val.strip() == ko:
+            return ko
+    return ""
+
+
+def color_from_image(item):
+    for url in item["_specImages"]:
+        try:
+            im = fw.load_image(url)
+        except Exception:
+            continue
+        cells = fw.cells_of(im)
+        for i, (cy, cx, txt) in enumerate(cells):
+            # inline "색상 : Sand" or label cell "색상"
+            m = re.match(r"^\s*색\s*상\s*[:：]\s*(.+)$", txt)
+            val = None
+            if m:
+                val = m.group(1)
+            elif re.match(r"^\s*색\s*상\s*[:：]?\s*$", txt):
+                # value cells strictly to the RIGHT of the 색상 label (exclude the label itself)
+                same = sorted([(c[1], c[2]) for c in cells
+                               if abs(c[0] - cy) <= 22 and c[1] > cx + 0.02
+                               and not re.match(r"^\s*색\s*상", c[2])])
+                if same:
+                    val = same[0][1]
+            if val:
+                val = val.strip()
+                if re.search(r"[,/·、&]| 및 |참조|상세", val):  # multiple options / non-colour
+                    return ""
+                return to_korean(val)
+    return ""
+
+
+def main():
+    path = sys.argv[1]
+    out = sys.argv[2] if len(sys.argv) > 2 else path
+    data = json.load(open(path))
+    targets = [x for x in data if not x.get("colorKorean") and x.get("_specImages")]
+    filled = 0
+    for i, item in enumerate(targets, 1):
+        try:
+            c = color_from_image(item)
+            if c:
+                item["colorKorean"] = c
+                filled += 1
+        except Exception as e:
+            print(f"  err {item.get('groupId')}: {e}")
+        if i % 25 == 0 or i == len(targets):
+            print(f"[imgcolor] {i}/{len(targets)} (filled {filled})")
+    json.dump(data, open(out, "w"), ensure_ascii=False, indent=2)
+    print(f"\n저장: {out}  (이미지 색상 채움 {filled})")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/crawl-gear/kovea-options.js
+++ b/.claude/skills/crawl-gear/kovea-options.js
@@ -1,0 +1,78 @@
+// Expand Cafe24 option selects into individual variant rows.
+// Some Kovea products are ONE product_no with an option dropdown (e.g. color 블루/옐로우);
+// each option must become its own product row (same groupId, distinct color/size).
+// Products without an option select are kept as a single row (their colour already came
+// from the name bracket or the image 색상 field).
+// Usage: node kovea-options.js <json> [out]
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36';
+const BASE = 'https://www.kovea.co.kr';
+
+const COLOR_KW = ['다크그레이', '라이트그레이', '그레이지', '그레이', '차콜', '블랙', '화이트', '아이보리', '카키베이지', '카키그린', '카키', '카모', '다크네이비', '네이비', '세이지', '올리브', '포레스트', '모스그린', '모스', '그린', '스카이블루', '블루', '레드', '오렌지', '옐로우', '머스타드', '다크브라운', '브라운', '코요테', '모카', '코코아', '크림', '샌드', '탄', '바닐라', '베이지', '핑크', '퍼플', '라벤더', '버건디', '와인', '골드', '실버', '민트', '코랄', '플린트'];
+const SIZE_KO = { XS: '엑스스몰', S: '스몰', M: '미디엄', L: '라지', XL: '엑스라지', XXL: '투엑스라지', '2XL': '투엑스라지', '3XL': '쓰리엑스라지' };
+const isColor = (v) => COLOR_KW.some((c) => v === c || v.includes(c));
+const sizeTok = (v) => { const m = v.match(/^(XS|S|M|L|XL|XXL|2XL|3XL)$/i); return m ? m[1].toUpperCase() : ''; };
+
+const fetchOptions = async (no) => {
+  const html = await (await fetch(`${BASE}/product/x/${no}/`, { headers: { 'User-Agent': UA } })).text();
+  const selects = [...html.matchAll(/<select[^>]*class="[^"]*ProductOption\d[^"]*"[^>]*>([\s\S]*?)<\/select>/gi)];
+  const dims = [];
+  for (const s of selects) {
+    const opts = [...s[1].matchAll(/<option[^>]*>([^<]*)<\/option>/g)]
+      .map((m) => m[1].trim())
+      .filter((t) => t && t !== '*' && !/^-+$/.test(t) && !/필수|선택해|옵션을|품절|sold ?out/i.test(t));
+    if (opts.length) dims.push(opts);
+  }
+  return dims;
+};
+
+// classify a dimension by its values → 'color' | 'size' | 'other'
+const dimKind = (vals) => {
+  if (vals.every((v) => isColor(v))) return 'color';
+  if (vals.every((v) => sizeTok(v))) return 'size';
+  if (vals.filter((v) => isColor(v)).length >= Math.ceil(vals.length / 2)) return 'color';
+  return 'other';
+};
+
+const main = async () => {
+  const path = process.argv[2];
+  const out = process.argv[3] || path;
+  const data = JSON.parse(readFileSync(path, 'utf8'));
+  const result = [];
+  let expanded = 0, addedRows = 0, i = 0;
+  for (const item of data) {
+    i++;
+    const no = item._productNo || (item.groupId || '').replace('kovea_', '');
+    let dims = [];
+    try { dims = await fetchOptions(no); } catch { dims = []; }
+    // Only COLOR / SIZE dimensions define catalog variants. Drop 'other' dimensions
+    // (pole length, model compatibility on A/S parts, etc.) — expanding those explodes
+    // into thousands of meaningless rows.
+    const kept = dims.map((vals) => ({ vals, kind: dimKind(vals) })).filter((d) => d.kind !== 'other');
+    if (!kept.length) { result.push(item); continue; }
+
+    let combos = [[]];
+    for (const d of kept) combos = combos.flatMap((c) => d.vals.map((v) => [...c, { v, kind: d.kind }]));
+
+    for (const combo of combos) {
+      const row = JSON.parse(JSON.stringify(item));
+      const suffixes = [];
+      for (const { v, kind } of combo) {
+        if (kind === 'color') { row.colorKorean = v; suffixes.push(v); }
+        else if (kind === 'size') { const s = sizeTok(v); row.size = s; row.sizeKorean = SIZE_KO[s] || s; suffixes.push(v); }
+      }
+      if (suffixes.length) row.nameKorean = `${item.nameKorean} (${suffixes.join(' / ')})`;
+      delete row._discontinued;
+      result.push(row);
+    }
+    expanded++;
+    addedRows += combos.length - 1;
+    console.log(`[options] ${item.nameKorean.slice(0, 26)} → ${combos.length}변형 [${kept.map((d) => d.kind)}]`);
+    if (i % 40 === 0) console.log(`  ...${i}/${data.length}`);
+  }
+  writeFileSync(out, JSON.stringify(result, null, 2));
+  console.log(`\n저장: ${out}  (옵션제품 ${expanded}개 → +${addedRows}행, 총 ${result.length})`);
+};
+
+main();

--- a/.claude/skills/crawl-gear/kovea-reimages.js
+++ b/.claude/skills/crawl-gear/kovea-reimages.js
@@ -1,0 +1,44 @@
+// Re-collect _specImages with the broadened rule (koveaimage CDN + /web/upload detail),
+// recovering products whose description images live outside the koveaimage CDN.
+// Usage: node kovea-reimages.js <json> [out]
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36';
+const BASE = 'https://www.kovea.co.kr';
+
+const collect = async (no) => {
+  try {
+    const html = await (await fetch(`${BASE}/product/x/${no}/`, { headers: { 'User-Agent': UA } })).text();
+    const imgs = [];
+    for (const m of html.matchAll(/koveaimage\.cafe24\.com\/[^"'\s)]+\.(?:jpg|jpeg|png)/gi)) imgs.push('https://' + m[0]);
+    for (const m of html.matchAll(/(?:src|ec-data-src)=["']([^"']*?\/web\/upload\/[^"']+\.(?:jpg|jpeg|png))/gi)) {
+      let u = m[1];
+      if (/\/category\/|icon|menu|btn|common|custom_\d|sns_|logo/i.test(u)) continue;
+      if (u.startsWith('//')) u = 'https:' + u; else if (u.startsWith('/')) u = BASE + u;
+      imgs.push(u);
+    }
+    return [...new Set(imgs)];
+  } catch { return null; }
+};
+
+const main = async () => {
+  const path = process.argv[2];
+  const out = process.argv[3] || path;
+  const data = JSON.parse(readFileSync(path, 'utf8'));
+  let gained = 0;
+  for (let i = 0; i < data.length; i++) {
+    const it = data[i];
+    const no = it._productNo || (it.groupId || '').replace('kovea_', '');
+    const before = (it._specImages || []).length;
+    const imgs = await collect(no);
+    if (imgs && imgs.length) {
+      it._specImages = imgs;
+      if (before === 0 && imgs.length > 0) gained++;
+    }
+    if ((i + 1) % 25 === 0 || i + 1 === data.length) console.log(`[reimages] ${i + 1}/${data.length} (0→N gained: ${gained})`);
+  }
+  writeFileSync(out, JSON.stringify(data, null, 2));
+  console.log(`\n저장: ${out}  (이미지 새로 확보: ${gained})`);
+};
+
+main();

--- a/.claude/skills/crawl-gear/kovea-sitemap-add.js
+++ b/.claude/skills/crawl-gear/kovea-sitemap-add.js
@@ -1,0 +1,98 @@
+// Add products that the category crawl missed (discontinued / refurb / non-major nav
+// categories) using the sitemap as the complete product list (incl. sold-out).
+// Sitemap has no category, so products are classified by NAME keyword (reliable for
+// Kovea: the Korean name states the type). Only major types are kept; products already
+// in the input JSON are skipped. New items get weight:0/specs:{} → run the spec pipeline.
+// Usage: node kovea-sitemap-add.js <existing-json> [out-json]
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36';
+const BASE = 'https://www.kovea.co.kr';
+
+// name-keyword → internal category. Order matters: accessories before their parent type.
+const RULES = [
+  ['tent_acc', /그라운드시트|풋프린트|이너텐트|이너 ?그라운드|스킨|루프/],
+  ['pouch', /캐리백|캐리 백|수납|파우치|보관가방/],
+  ['tarp', /타프|그늘막|쉐이드|쉐도우캐스터/],
+  ['tent', /텐트|쉘터|돔(?!구장)|쉘\b|이너|플라이|쉘터/],
+  ['sleeping_bag', /침낭|슬리핑|이너 ?시트|라이너/],
+  ['mat', /매트|토퍼|에어 ?매트|매트리스/],
+  ['chair', /체어|의자|스툴|벤치|릴렉서/],
+  ['table', /테이블/],
+  ['lighting', /랜턴|헤드랜턴|등불|라이트(?!.*테이블)/],
+];
+const catOf = (name) => {
+  for (const [k, re] of RULES) if (re.test(name)) return k;
+  return null;
+};
+
+const SIZE_KO = { XS: '엑스스몰', S: '스몰', M: '미디엄', L: '라지', XL: '엑스라지', XXL: '투엑스라지', '2XL': '투엑스라지', '3XL': '쓰리엑스라지' };
+const COLOR_KW = ['다크그레이', '라이트그레이', '그레이지', '그레이', '차콜', '블랙', '화이트', '아이보리', '카키그린', '카키', '카모', '다크네이비', '네이비', '세이지', '올리브', '포레스트', '그린', '스카이블루', '블루', '레드', '오렌지', '옐로우', '머스타드', '다크브라운', '브라운', '코요테', '모카', '크림', '샌드', '탄', '베이지', '핑크', '퍼플', '라벤더', '버건디', '와인', '골드', '실버', '민트', '코랄'];
+const findColor = (s) => COLOR_KW.find((c) => s === c || s.includes(c)) || '';
+const extractVariant = (name) => {
+  let color = '', base = name;
+  const paren = name.match(/\(([^)]+)\)\s*$/);
+  if (paren) { const c = findColor(paren[1].trim()); if (c) { color = paren[1].trim(); base = name.replace(/\s*\([^)]*\)\s*$/, '').trim(); } }
+  if (!color) { const last = base.split(/\s+/).pop(); if (last && findColor(last) === last) { color = last; base = base.replace(/\s+\S+$/, '').trim(); } }
+  const sm = base.match(/\s(XS|S|M|L|XL|XXL|2XL|3XL)$/i);
+  return { color, size: sm ? sm[1].toUpperCase() : '' };
+};
+
+const fetchDetail = async (no) => {
+  const html = await (await fetch(`${BASE}/product/x/${no}/`, { headers: { 'User-Agent': UA } })).text();
+  const nm = html.match(/<meta[^>]*property=["']og:title["'][^>]*content=["']([^"']+)["']/i);
+  const name = nm ? nm[1].replace(/\s*-\s*코베아\s*$/, '').replace(/\s+/g, ' ').trim() : '';
+  const imgEl = html.match(/<meta[^>]*property=["']og:image["'][^>]*content=["']([^"']+)["']/i);
+  let imageUrl = imgEl ? imgEl[1].split('?')[0] : '';
+  if (imageUrl.startsWith('//')) imageUrl = 'https:' + imageUrl;
+  const imgs = [];
+  for (const m of html.matchAll(/koveaimage\.cafe24\.com\/[^"'\s)]+\.(?:jpg|jpeg|png)/gi)) imgs.push('https://' + m[0]);
+  for (const m of html.matchAll(/(?:src|ec-data-src)=["']([^"']*?\/web\/upload\/[^"']+\.(?:jpg|jpeg|png))/gi)) {
+    let u = m[1];
+    if (/\/category\/|icon|menu|btn|common|custom_\d|sns_|logo/i.test(u)) continue;
+    if (u.startsWith('//')) u = 'https:' + u; else if (u.startsWith('/')) u = BASE + u;
+    imgs.push(u);
+  }
+  return { name, imageUrl, specImages: [...new Set(imgs)] };
+};
+
+const main = async () => {
+  const path = process.argv[2];
+  const out = process.argv[3] || path;
+  const data = JSON.parse(readFileSync(path, 'utf8'));
+  const have = new Set(data.map((x) => x._productNo || (x.groupId || '').replace('kovea_', '')));
+
+  const xml = await (await fetch(`${BASE}/sitemap.xml`, { headers: { 'User-Agent': UA } })).text();
+  const seen = new Map();
+  for (const m of xml.matchAll(/\/product\/([^/<]+)\/(\d+)\//g)) {
+    if (!seen.has(m[2])) seen.set(m[2], decodeURIComponent(m[1]).replace(/-/g, ' '));
+  }
+  const candidates = [...seen.entries()].filter(([no]) => !have.has(no));
+  console.log(`[sitemap] ${seen.size} products, ${candidates.length} not yet crawled`);
+
+  let added = 0, i = 0;
+  for (const [no, slugName] of candidates) {
+    i++;
+    if (!catOf(slugName)) continue; // skip non-major types (slug pre-filter)
+    let detail;
+    try { detail = await fetchDetail(no); } catch { continue; }
+    const nameKorean = detail.name || slugName;
+    const category = catOf(nameKorean) || catOf(slugName);
+    if (!category) continue;
+    const { color, size } = extractVariant(nameKorean);
+    data.push({
+      groupId: `kovea_${no}`, category, company: 'kovea', companyKorean: '코베아',
+      name: '', nameKorean, color: '', colorKorean: color,
+      size, sizeKorean: size ? (SIZE_KO[size] || size) : '',
+      weight: 0, imageUrl: detail.imageUrl, specs: {},
+      _productNo: no, _detailUrl: `${BASE}/product/x/${no}/`,
+      _specImages: detail.specImages, _source: 'sitemap', _discontinued: true,
+    });
+    added++;
+    if (added % 20 === 0) console.log(`[sitemap]   added ${added}`);
+  }
+  writeFileSync(out, JSON.stringify(data, null, 2));
+  console.log(`\n저장: ${out}  (신규 추가 ${added}, 총 ${data.length})`);
+};
+
+main();

--- a/.claude/skills/crawl-gear/kovea-sleeptemp.py
+++ b/.claude/skills/crawl-gear/kovea-sleeptemp.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# Fill sleeping-bag temperatures (specs.comfortTemp / limitTemp) by OCR-reading the
+# detail image's ISO 23537 table, e.g.  Comfort 15°C ~ 0°C / Lower Limit -10°C ~ -15°C.
+# The temp table sits MID-image (not the bottom 고시 band), so we tile the whole image.
+# Detail images may live on koveaimage CDN OR /web/upload/NNEditor (Cafe24 editor) — both
+# are collected here. Only sleeping_bag items are touched; other fields are preserved.
+# Usage: python3 kovea-sleeptemp.py <json> [out-json]
+import json
+import re
+import sys
+import urllib.parse
+import urllib.request
+from io import BytesIO
+
+import Vision
+import Quartz
+from PIL import Image
+
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36"
+REFERER = "https://www.kovea.co.kr/"
+TILE_H = 1500
+OVERLAP = 160
+
+
+def http_get(url):
+    safe = urllib.parse.quote(url, safe=":/?=&%")
+    req = urllib.request.Request(safe, headers={"User-Agent": UA, "Referer": REFERER})
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return r.read()
+
+
+def detail_images(product_no):
+    html = http_get(f"https://www.kovea.co.kr/product/x/{product_no}/").decode("utf-8", "ignore")
+    imgs = []
+    for m in re.finditer(r"koveaimage\.cafe24\.com/[^\"'\s)]+\.(?:jpg|jpeg|png)", html, re.I):
+        imgs.append("https://" + m.group(0))
+    for m in re.finditer(r"""(?:src|ec-data-src)=["']([^"']*?/web/upload/[^"']+\.(?:jpg|jpeg|png))""", html, re.I):
+        u = m.group(1)
+        if re.search(r"/category/|icon|menu|btn|common|custom_\d", u, re.I):
+            continue
+        imgs.append(("https://www.kovea.co.kr" + u) if u.startswith("/") else u.replace("//", "https://", 1) if u.startswith("//") else u)
+    # de-dupe, keep order
+    seen, out = set(), []
+    for u in imgs:
+        if u not in seen:
+            seen.add(u)
+            out.append(u)
+    return out
+
+
+def load_image(url):
+    return Image.open(BytesIO(http_get(url))).convert("RGB")
+
+
+def ocr_pil(im):
+    bio = BytesIO()
+    im.save(bio, format="PNG")
+    data = bio.getvalue()
+    src = Quartz.CGImageSourceCreateWithData(data, None)
+    cg = Quartz.CGImageSourceCreateImageAtIndex(src, 0, None)
+    req = Vision.VNRecognizeTextRequest.alloc().init()
+    req.setRevision_(3)
+    req.setRecognitionLevel_(0)
+    req.setUsesLanguageCorrection_(False)
+    req.setRecognitionLanguages_(["ko-KR", "en-US"])
+    h = Vision.VNImageRequestHandler.alloc().initWithCGImage_options_(cg, None)
+    h.performRequests_error_([req], None)
+    return [o.topCandidates_(1)[0].string() for o in (req.results() or []) if o.topCandidates_(1)]
+
+
+def ocr_full(im):
+    w, h = im.size
+    out = []
+    y = 0
+    while y < h:
+        out.extend(ocr_pil(im.crop((0, y, w, min(h, y + TILE_H)))))
+        y += TILE_H - OVERLAP
+    return "\n".join(out)
+
+
+def _nums(seg):
+    return [int(n) for n in re.findall(r"(-?\d+)\s*[°˚]?\s*[C℃]", seg)]
+
+
+def parse_temps(text):
+    t = text.replace(" ", "")
+    res = {}
+    ci = next((t.find(k) for k in ("Comfort", "쾌적온도") if t.find(k) >= 0), -1)
+    li = next((t.find(k) for k in ("LowerLimit", "Lowerlimit", "한계온도", "최저온도") if t.find(k) >= 0), -1)
+    # comfort window stops at the LowerLimit label so it can't swallow limit numbers.
+    if ci >= 0:
+        end = li if (li > ci) else ci + 30
+        nums = _nums(t[ci + 7:end])
+        if nums:
+            res["comfortTemp"] = min(nums)  # coldest end of the comfort range
+    if li >= 0:
+        nums = _nums(t[li + 7:li + 35])
+        if nums:
+            res["limitTemp"] = min(nums)
+
+    # Label-column / value-column layout (e.g. 리미트 800): labels "Comfort / Lower Limit"
+    # render in one column and values "-10°C -25°C" in another → window logic misses them.
+    # Collect standalone °C values (not C/F pairs, not laundry) after the first label.
+    if "comfortTemp" not in res and (ci >= 0 or li >= 0):
+        start = min(x for x in (ci, li) if x >= 0)
+        vals = []
+        for m in re.finditer(r"(-?\d+)\s*[°˚]?C(?!\s*/\s*[\d.]+\s*[°˚]?F)", t[start:]):
+            ctx = t[start + m.start() - 6:start + m.start()]
+            if re.search(r"물|세탁|약", ctx):
+                continue
+            vals.append(int(m.group(1)))
+        if len(vals) >= 2:
+            res["comfortTemp"] = vals[0]
+            res.setdefault("limitTemp", vals[1])
+
+    # Fallback: 3-tier "N°C / N°F" scale (쾌적 / 숙면·밀착 / 극한). The "/°F" pairing
+    # distinguishes sleeping temps from laundry temps (e.g. "물의 온도 30°C", no /F).
+    if "comfortTemp" not in res or "limitTemp" not in res:
+        cs = [int(m.group(1)) for m in re.finditer(r"(-?\d+)\s*[°˚]?C\s*/\s*[\d.]+\s*[°˚]?F", t)]
+        if len(cs) >= 2:
+            res.setdefault("comfortTemp", cs[0])   # 1st tier = 쾌적/안락 (comfort)
+            res.setdefault("limitTemp", cs[1])      # 2nd tier = 숙면/밀착 (lower limit)
+    return res
+
+
+def process(item):
+    no = item.get("_productNo") or item["groupId"].replace("kovea_", "")
+    imgs = item.get("_specImages") or []
+    if not imgs:
+        try:
+            imgs = detail_images(no)
+            item["_specImages"] = imgs
+        except Exception:
+            imgs = []
+    # the ISO temp table is in the big description image — try the tallest first
+    cand = sorted(imgs, key=lambda u: 0, reverse=True)
+    found = {}
+    for url in imgs:
+        try:
+            im = load_image(url)
+        except Exception:
+            continue
+        if im.size[1] < 800:  # skip tiny images
+            continue
+        txt = ocr_full(im)
+        found = parse_temps(txt)
+        if found:
+            break
+    if found:
+        item.setdefault("specs", {})
+        item["specs"].update(found)
+        return True
+    return False
+
+
+def main():
+    path = sys.argv[1]
+    out = sys.argv[2] if len(sys.argv) > 2 else path
+    data = json.load(open(path))
+    sbs = [x for x in data if x.get("category") == "sleeping_bag"]
+    ok = 0
+    for i, item in enumerate(sbs, 1):
+        try:
+            if process(item):
+                ok += 1
+                print(f"  [{i}/{len(sbs)}] {item['nameKorean'][:30]} → {item['specs'].get('comfortTemp')}/{item['specs'].get('limitTemp')}")
+            else:
+                print(f"  [{i}/{len(sbs)}] {item['nameKorean'][:30]} → 온도 못찾음")
+        except Exception as e:
+            print(f"  err {item.get('groupId')}: {e}")
+    json.dump(data, open(out, "w"), ensure_ascii=False, indent=2)
+    print(f"\n저장: {out}  (온도 {ok}/{len(sbs)})")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/crawl-gear/kovea-specs.py
+++ b/.claude/skills/crawl-gear/kovea-specs.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+# Fill weight + specs on a Kovea crawl JSON by OCR-reading the spec image.
+# Korean products embed specs in the "상품 정보 제공 고시" table (and sometimes an English
+# "Specification" block) at the BOTTOM of the last detail image (koveaimage CDN).
+# Pipeline per product: download last _specImage (cache) → crop bottom band → tile →
+# Vision OCR (ko-KR, fast level) → join text → regex-parse → map to category specs.
+#
+# Usage: python3 kovea-specs.py <crawl-json> [out-json]
+import json
+import os
+import re
+import sys
+import urllib.parse
+import urllib.request
+from io import BytesIO
+
+import Vision
+import Quartz
+from Foundation import NSURL
+from PIL import Image
+
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36"
+REFERER = "https://www.kovea.co.kr/"
+CACHE = "/tmp/kovea-orig"
+os.makedirs(CACHE, exist_ok=True)
+
+BOTTOM_PX = 7000   # how much of the image bottom to scan (고시 is near the end)
+TILE_H = 1500
+OVERLAP = 160
+SPEC_MARKERS = ("상품 정보 제공 고시", "상품정보제공고시", "Specification", "SPECIFICATION", "크기,중량", "크기, 중량")
+
+
+def fetch_image(url):
+    key = re.sub(r"[^A-Za-z0-9_.]", "_", url.split("/")[-1])
+    path = os.path.join(CACHE, key)
+    if os.path.exists(path) and os.path.getsize(path) > 1000:
+        return Image.open(path).convert("RGB")
+    safe = urllib.parse.quote(url, safe=":/?=&%")
+    req = urllib.request.Request(safe, headers={"User-Agent": UA, "Referer": REFERER})
+    with urllib.request.urlopen(req, timeout=60) as r:
+        data = r.read()
+    open(path, "wb").write(data)
+    return Image.open(BytesIO(data)).convert("RGB")
+
+
+def ocr_pil(im):
+    """OCR a PIL image via macOS Vision (Korean, fast level). Returns list of text lines."""
+    bio = BytesIO()
+    im.save(bio, format="PNG")
+    data = bio.getvalue()
+    provider = Quartz.CGDataProviderCreateWithCFData(data)
+    # decode PNG → CGImage
+    src = Quartz.CGImageSourceCreateWithData(data, None)
+    cg = Quartz.CGImageSourceCreateImageAtIndex(src, 0, None)
+    req = Vision.VNRecognizeTextRequest.alloc().init()
+    req.setRevision_(3)
+    req.setRecognitionLevel_(0)  # fast — only level with Korean on this macOS
+    req.setUsesLanguageCorrection_(False)
+    req.setRecognitionLanguages_(["ko-KR", "en-US"])
+    handler = Vision.VNImageRequestHandler.alloc().initWithCGImage_options_(cg, None)
+    handler.performRequests_error_([req], None)
+    lines = []
+    for obs in (req.results() or []):
+        cand = obs.topCandidates_(1)
+        if cand:
+            lines.append(cand[0].string())
+    return lines
+
+
+def ocr_bottom_text(im):
+    """Tile the bottom band of a tall image and OCR each tile; return joined text."""
+    w, h = im.size
+    band = im.crop((0, max(0, h - BOTTOM_PX), w, h))
+    bw, bh = band.size
+    text = []
+    y = 0
+    while y < bh:
+        tile = band.crop((0, y, bw, min(bh, y + TILE_H)))
+        text.extend(ocr_pil(tile))
+        y += TILE_H - OVERLAP
+    return "\n".join(text)
+
+
+def grams(num, unit):
+    v = float(num)
+    return int(round(v * 1000)) if unit.lower().startswith("k") else int(round(v))
+
+
+def parse_specs(text, category):
+    """Extract a normalized fact dict from the OCR'd spec text."""
+    full = text.replace(" ", "")  # spacing in OCR is unreliable; match on despaced text
+    # Restrict to the 고시/Specification region so marketing copy (which also says
+    # "재질", "중량" etc.) doesn't produce false matches.
+    markers = ["상품정보제공고시", "품명및모델명", "크기,중량", "크기중량", "Specification", "SPECIFICATION"]
+    idxs = [full.find(mk) for mk in markers if full.find(mk) >= 0]
+    has_spec = bool(idxs)
+    t = full[min(idxs):] if idxs else full
+    facts = {"_hasSpec": has_spec}
+
+    # weight: 중량 N kg/g  (take the first 중량 occurrence)
+    m = re.search(r"중량[:：]?\(?([\d.]+)\)?\s*(kg|g)", t, re.I) or re.search(r"무게[:：]?([\d.]+)\s*(kg|g)", t, re.I)
+    if m:
+        facts["weight"] = grams(m.group(1), m.group(2))
+    else:
+        # stacked-label 고시 (label column / value column) breaks the inline match →
+        # fall back to the first standalone weight not tied to load/waterproof.
+        for mm in re.finditer(r"([\d.]+)\s*(kg|g)\b", t, re.I):
+            ctx = t[max(0, mm.start() - 6):mm.start()]
+            if re.search(r"하중|내수압|수압", ctx):
+                continue
+            facts["weight"] = grams(mm.group(1), mm.group(2))
+            break
+
+    # waterproof: 내수압 N mm  (max value if several)
+    wp = [int(x.replace(",", "")) for x in re.findall(r"내수압[:：]?([\d,]+)\s*mm", t, re.I)]
+    if wp:
+        facts["waterproofRating"] = max(wp)
+
+    # capacity: 수용인원 N인
+    m = re.search(r"수용인원[:：]?(\d+)\s*인", t)
+    if m:
+        facts["capacity"] = int(m.group(1))
+
+    # size: first NxNxN cm (prefer 본체/외형 dims). keep raw despaced.
+    m = re.search(r"(\d{2,4}(?:[xX×]\d{2,4}){1,2}\s*cm)", t)
+    if m:
+        facts["size"] = m.group(1).replace("×", "x").replace("X", "x")
+
+    # pole material
+    if re.search(r"폴[:：].{0,12}(듀랄루민|두랄루민)", t):
+        facts["poleMaterial"] = "duralumin"
+    elif re.search(r"폴[:：].{0,12}카본", t):
+        facts["poleMaterial"] = "carbon"
+    elif re.search(r"폴[:：].{0,12}(알루미늄|알루미늡)", t):
+        facts["poleMaterial"] = "aluminum"
+    elif re.search(r"폴[:：].{0,12}(화이바|파이버|fiber|글라스|grass)", t, re.I):
+        facts["poleMaterial"] = "fiberglass"
+
+    # fabrics: detect within the 고시 region (already excludes marketing copy above the
+    # 고시 marker). The 재질 sub-block layout varies too much to slice reliably.
+    if "나일론" in t:
+        facts["_hasNylon"] = True
+    if re.search(r"폴리에스테르|폴리에스터", t):
+        facts["_hasPoly"] = True
+
+    # 사용온도 / 내한온도 (sleeping bag)
+    m = re.search(r"(?:사용가능온도|사용온도|내한온도|적정온도)[:：]?\(?(-?\d+)", t)
+    if m:
+        facts["temp"] = int(m.group(1))
+    # 충전재 (sleeping bag)
+    if re.search(r"(거위털|구스다운|덕다운|오리털|다운)", t):
+        facts["fill"] = "down"
+    elif re.search(r"(중공사|폴리|신서레이트|화학솜|인견)", t):
+        facts["fill"] = "synthetic"
+
+    # 최대하중 (chair/table)
+    m = re.search(r"(?:최대하중|내하중|허용하중)[:：]?약?([\d,]+)\s*kg", t)
+    if m:
+        facts["maxLoad"] = int(m.group(1).replace(",", ""))
+
+    # lighting: 밝기(루멘), 전원/배터리, 사용/점등/연소 시간
+    m = re.search(r"([\d,]+)\s*(?:lm|루멘|流明)", t, re.I) or re.search(r"(?:밝기|광량)[:：]?약?([\d,]+)", t)
+    if m:
+        facts["lumens"] = int(m.group(1).replace(",", ""))
+    if re.search(r"가스|이소부탄|부탄", t):
+        facts["battery"] = "gas"
+    elif re.search(r"충전|리튬|배터리|usb", t, re.I):
+        facts["battery"] = "rechargeable"
+    elif re.search(r"건전지|AA|AAA|알카라인", t, re.I):
+        facts["battery"] = "disposable"
+    m = re.search(r"(?:연소시간|점등시간|사용시간|런타임)[:：]?약?([\d.]+)\s*시간", t)
+    if m:
+        facts["runtime"] = float(m.group(1))
+
+    return facts
+
+
+def to_specs(facts, category):
+    """Map normalized facts to the category's specs object."""
+    s = {}
+    mat_main = "나일론" if facts.get("_hasNylon") else ("폴리에스테르" if facts.get("_hasPoly") else "")
+
+    if category in ("tent", "tarp", "shelter"):
+        if "capacity" in facts:
+            s["capacity"] = facts["capacity"]
+        if facts.get("_hasNylon"):
+            s["flyMaterial"] = "나일론"
+        if facts.get("_hasPoly"):
+            s["innerMaterial"] = "폴리에스테르"
+        if "poleMaterial" in facts:
+            s["poleMaterial"] = facts["poleMaterial"]
+        if "waterproofRating" in facts:
+            s["waterproofRating"] = facts["waterproofRating"]
+    elif category == "mat":
+        if mat_main:
+            s["material"] = mat_main
+        if "size" in facts:
+            s["openSize"] = facts["size"]
+    elif category == "sleeping_bag":
+        if "fill" in facts:
+            s["fillMaterial"] = facts["fill"]
+        if "temp" in facts:
+            s["limitTemp"] = facts["temp"]
+    elif category in ("chair", "table"):
+        if mat_main:
+            s["material"] = mat_main
+        if "maxLoad" in facts:
+            s["maxLoad"] = facts["maxLoad"]
+        if "size" in facts:
+            s["packedSize"] = facts["size"]
+    elif category == "lighting":
+        if "lumens" in facts:
+            s["maxBrightness"] = facts["lumens"]
+        if "battery" in facts:
+            s["batteryType"] = facts["battery"]
+        if "runtime" in facts:
+            s["maxRuntime"] = facts["runtime"]
+    else:
+        if mat_main:
+            s["material"] = mat_main
+        if "size" in facts:
+            s["size"] = facts["size"]
+    return s
+
+
+def process(item):
+    imgs = item.get("_specImages") or []
+    if not imgs:
+        return False
+    cat = item.get("category", "etc")
+    # 고시 is at the bottom of the LAST image; if markers missing, try earlier ones.
+    for url in reversed(imgs[-3:]):
+        try:
+            im = fetch_image(url)
+        except Exception as e:
+            print(f"   fetch fail {item['groupId']}: {e}")
+            continue
+        text = ocr_bottom_text(im)
+        facts = parse_specs(text, cat)
+        # Accept only on real spec indicators (marker found OR a weight parsed),
+        # so a junk last image doesn't short-circuit before the real 고시 image.
+        if facts.get("_hasSpec") or "weight" in facts:
+            if "weight" in facts:
+                item["weight"] = facts["weight"]
+            item["specs"] = to_specs(facts, cat)
+            return True
+    return False
+
+
+def main():
+    path = sys.argv[1]
+    out = sys.argv[2] if len(sys.argv) > 2 else path.replace(".json", "-spec.json")
+    data = json.load(open(path))
+    ok = 0
+    for i, item in enumerate(data, 1):
+        try:
+            if process(item):
+                ok += 1
+        except Exception as e:
+            print(f"   error {item.get('groupId')}: {e}")
+        if i % 5 == 0 or i == len(data):
+            print(f"[kovea-specs] {i}/{len(data)} (specs filled: {ok})")
+    json.dump(data, open(out, "w"), ensure_ascii=False, indent=2)
+    print(f"\n저장: {out}  (specs {ok}/{len(data)})")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/crawl-gear/ocr.py
+++ b/.claude/skills/crawl-gear/ocr.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# macOS Vision OCR (Korean+English) → JSON lines with text + position.
+# Usage: python3 ocr.py <image-path>
+# Output: [{"t": text, "x":, "y": (from top, 0..1), "w":, "h":}, ...] sorted top→bottom.
+import json
+import sys
+
+import Vision
+import Quartz
+from Foundation import NSURL
+
+
+def ocr(path):
+    url = NSURL.fileURLWithPath_(path)
+    src = Quartz.CGImageSourceCreateWithURL(url, None)
+    if src is None:
+        raise RuntimeError(f"cannot load {path}")
+    cg = Quartz.CGImageSourceCreateImageAtIndex(src, 0, None)
+
+    req = Vision.VNRecognizeTextRequest.alloc().init()
+    req.setRevision_(3)
+    # NOTE: on this macOS, Korean (ko-KR) is only available at the FAST level (0).
+    # Accurate (1) supports Latin languages only. Fast is plenty for printed spec tables.
+    req.setRecognitionLevel_(0)
+    req.setUsesLanguageCorrection_(False)
+    req.setRecognitionLanguages_(["ko-KR", "en-US"])
+
+    handler = Vision.VNImageRequestHandler.alloc().initWithCGImage_options_(cg, None)
+    ok = handler.performRequests_error_([req], None)
+
+    out = []
+    for obs in (req.results() or []):
+        cand = obs.topCandidates_(1)
+        if not cand:
+            continue
+        text = cand[0].string()
+        bb = obs.boundingBox()  # origin bottom-left, normalized
+        x = bb.origin.x
+        y_top = 1.0 - (bb.origin.y + bb.size.height)
+        out.append({
+            "t": text,
+            "x": round(float(x), 4),
+            "y": round(float(y_top), 4),
+            "w": round(float(bb.size.width), 4),
+            "h": round(float(bb.size.height), 4),
+        })
+    out.sort(key=lambda r: (r["y"], r["x"]))
+    return out
+
+
+if __name__ == "__main__":
+    print(json.dumps(ocr(sys.argv[1]), ensure_ascii=False))

--- a/.claude/skills/crawl-gear/out/kovea-full.json
+++ b/.claude/skills/crawl-gear/out/kovea-full.json
@@ -1,0 +1,7687 @@
+[
+  {
+    "groupId": "kovea_2830",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "고스트 플러스 텐트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 16000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/557a79cfa5c86f1449dcb1e5b4f6c515.jpg",
+    "specs": {
+      "capacity": 4,
+      "flyMaterial": "나일론",
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "duralumin",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2830",
+    "_detailUrl": "https://www.kovea.co.kr/product/고스트-플러스-텐트/2830/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9TO-01ZZ000/KECY9TO-01ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9TO-01ZZ000/KECY9TO-01ZZ000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_3085",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "[사전판매/블랙] 대형 에어텐트 고스트 팬텀 에어 4인용 가족 캠핑 (모스)",
+    "color": "",
+    "colorKorean": "모스",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 33000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/8b5ca983611fa4d20bc94666ad4fc95e.jpg",
+    "specs": {
+      "flyMaterial": "나일론",
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "aluminum",
+      "waterproofRating": 2000
+    },
+    "_productNo": "3085",
+    "_detailUrl": "https://www.kovea.co.kr/product/대형-에어텐트-고스트-팬텀-에어-4인용-가족-캠핑/3085/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29TO-03MS000/KEC29TO_03_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29TO-03MS000/KEC29TO_03_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29TO-03MS000/KEC29TO_03_04.jpg",
+      "https://www.kovea.co.kr/web/upload/NNEditor/20260608/EC82ACECA084ED8C90EBA7A420EC8381EC84B820EC8381EB8BA8.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_3085",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "[사전판매/블랙] 대형 에어텐트 고스트 팬텀 에어 4인용 가족 캠핑 (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 33000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/8b5ca983611fa4d20bc94666ad4fc95e.jpg",
+    "specs": {
+      "flyMaterial": "나일론",
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "aluminum",
+      "waterproofRating": 2000
+    },
+    "_productNo": "3085",
+    "_detailUrl": "https://www.kovea.co.kr/product/대형-에어텐트-고스트-팬텀-에어-4인용-가족-캠핑/3085/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29TO-03MS000/KEC29TO_03_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29TO-03MS000/KEC29TO_03_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29TO-03MS000/KEC29TO_03_04.jpg",
+      "https://www.kovea.co.kr/web/upload/NNEditor/20260608/EC82ACECA084ED8C90EBA7A420EC8381EC84B820EC8381EB8BA8.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2825",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "네스트 W (탄)",
+    "color": "",
+    "colorKorean": "탄",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 21000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/f38cd5a1d3a4db7a1fa5727e6099bf74.jpg",
+    "specs": {
+      "capacity": 4,
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "aluminum",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2825",
+    "_detailUrl": "https://www.kovea.co.kr/product/네스트-w-탄/2825/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9TO-07TN000/KECO9TO-07TN000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9TO-07TN000/KECO9TO-07TN000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2947",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "몬스터 아이보리",
+    "color": "",
+    "colorKorean": "아이보리",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 18000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/a2632c102564a274bbbab6e2382338e3.jpg",
+    "specs": {
+      "capacity": 4,
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "duralumin",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2947",
+    "_detailUrl": "https://www.kovea.co.kr/product/몬스터-아이보리/2947/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9TO-17IV000/KECO9TO-17IV000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_3086",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "필드640 대형 텐트 4인용 가족 캠핑 터널형",
+    "color": "",
+    "colorKorean": "샌드",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 25000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/c27ebfbac148c04f10219d964a24c0b2.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "duralumin",
+      "waterproofRating": 2000
+    },
+    "_productNo": "3086",
+    "_detailUrl": "https://www.kovea.co.kr/product/필드640-대형-텐트-4인용-가족-캠핑-터널형/3086/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29TO-02SD000/KEC29TO-02SD000-01.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29TO-02SD000/KEC29TO-02SD000-03.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2832",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "고스트 플러스 텐트 (차콜) / 4인용 거실형 캠핑 텐트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 16000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/b0a8d49c111998398c389fcf9ff90499.jpg",
+    "specs": {
+      "capacity": 4,
+      "flyMaterial": "나일론",
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "duralumin",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2832",
+    "_detailUrl": "https://www.kovea.co.kr/product/고스트-플러스-텐트-차콜-4인용-거실형-캠핑-텐트/2832/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9TO-09CH000/KECO9TO-09CH000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9TO-09CH000/KECO9TO-09CH000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2827",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "네스트 T (탄)",
+    "color": "",
+    "colorKorean": "탄",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 20000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/c90b03ef6179020132951b6752b7c40b.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "aluminum",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2827",
+    "_detailUrl": "https://www.kovea.co.kr/product/네스트-t-탄/2827/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9TO-05TN000/KECP9TO-05TN000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2804",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "T코어 (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 3500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/e8dd4d3433888b76c3ac14676ad1aed6.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "duralumin",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2804",
+    "_detailUrl": "https://www.kovea.co.kr/product/t코어-블랙/2804/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9TL-04BK000/KECX9TL-04BK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2838",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "고스트 캐스퍼 (탄)",
+    "color": "",
+    "colorKorean": "탄",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 8400,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/c1a2b250cc33102992c0e1b2e75f29b9.jpg",
+    "specs": {
+      "flyMaterial": "나일론",
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "duralumin",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2838",
+    "_detailUrl": "https://www.kovea.co.kr/product/고스트-캐스퍼-탄/2838/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9TO-06TN000/KECP9TO-06TN000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2817",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "투어링 II",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 14500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/a8e229b41986711b15c18c13d7bd11cd.jpg",
+    "specs": {
+      "capacity": 4,
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "fiberglass",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2817",
+    "_detailUrl": "https://www.kovea.co.kr/product/투어링-ii/2817/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9TO-14ZZ000/KECY9TO-14ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9TO-14ZZ000/KECY9TO-14ZZ000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2783",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "와일드 폭스트롯2 4인용 가족 캠핑 텐트",
+    "color": "",
+    "colorKorean": "샌드",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 19000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/6f3db8d1eac0a709fa267bc3e5da57d2.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "duralumin",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2783",
+    "_detailUrl": "https://www.kovea.co.kr/product/와일드-폭스트롯2-4인용-가족-캠핑-텐트/2783/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19TO-02SD000/KEC19TO-02SD000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2809",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "와일드 알파 (그레이)",
+    "color": "",
+    "colorKorean": "그레이",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 12000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/35437143d8f06c62572018168182f616.jpg",
+    "specs": {
+      "flyMaterial": "나일론",
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "duralumin",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2809",
+    "_detailUrl": "https://www.kovea.co.kr/product/와일드-알파-그레이/2809/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9TW-03GR000/KECP9TW-03GR000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_3093",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "베이스 코트 텐트 1인용 텐트",
+    "color": "",
+    "colorKorean": "샌드",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/61ce0d9e7d331a65aae50eb19ce6be80.jpg",
+    "specs": {
+      "flyMaterial": "나일론",
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "aluminum",
+      "waterproofRating": 5000
+    },
+    "_productNo": "3093",
+    "_detailUrl": "https://www.kovea.co.kr/product/베이스-코트-텐트-1인용-텐트/3093/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29TM-01SD000/KEC29TM-01SD.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2802",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "X코어N (탄)",
+    "color": "",
+    "colorKorean": "탄",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2900,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/f78b3dc65f3e66f9852852de79f4d586.jpg",
+    "specs": {
+      "flyMaterial": "나일론",
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "duralumin"
+    },
+    "_productNo": "2802",
+    "_detailUrl": "https://www.kovea.co.kr/product/x코어n-탄/2802/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9TL-01ZZ000/KECX9TL-01ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9TL-01ZZ000/KECX9TL-01ZZ000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2808",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "와일드 알파 (카모)",
+    "color": "",
+    "colorKorean": "카모",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 12000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/f2158a612f149e0c6ff6e489d5768425.jpg",
+    "specs": {
+      "flyMaterial": "나일론",
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "duralumin",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2808",
+    "_detailUrl": "https://www.kovea.co.kr/product/와일드-알파-카모/2808/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9TW-02KC000/KECP9TW-02KC000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2787",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "와일드 델타 블랙 쉘터형 캠핑 텐트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 17500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/e842eeb27d2fe098b707df4808b2108a.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "duralumin",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2787",
+    "_detailUrl": "https://www.kovea.co.kr/product/와일드-델타-블랙-쉘터형-캠핑-텐트/2787/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_04/KEC19TW-01BK000/KEC19TW-01BK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2840",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "레트로 하우스",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 22000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/37987f8b132cbc1b88dcc7a895cf286a.jpg",
+    "specs": {
+      "capacity": 5,
+      "innerMaterial": "폴리에스테르",
+      "waterproofRating": 5000
+    },
+    "_productNo": "2840",
+    "_detailUrl": "https://www.kovea.co.kr/product/레트로-하우스/2840/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9TA-01ZZ000/KECO9TA-01ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9TA-01ZZ000/KECO9TA-01ZZ000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_3125",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "원터치텐트 팝 허브 팝업형 캠핑 텐트",
+    "color": "",
+    "colorKorean": "라이트블루",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 5000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/7984ff5b570511afcf80d665910b0455.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "fiberglass",
+      "waterproofRating": 2000
+    },
+    "_productNo": "3125",
+    "_detailUrl": "https://www.kovea.co.kr/product/원터치텐트-팝-허브-팝업형-캠핑-텐트/3125/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29TI-01LL000/KEC29TI-01LL.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_3094",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "코어 라이트 1.5 경량 1~2인용 캠핑 텐트",
+    "color": "",
+    "colorKorean": "라이트그레이",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1700,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/b488bb052901a49087dff69378552bbe.jpg",
+    "specs": {
+      "flyMaterial": "나일론",
+      "poleMaterial": "aluminum",
+      "waterproofRating": 3000
+    },
+    "_productNo": "3094",
+    "_detailUrl": "https://www.kovea.co.kr/product/코어-라이트-15-경량-12인용-캠핑-텐트/3094/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29TL-01LG000/KEC29TL-01LG000_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29TL-01LG000/KEC29TL-01LG000_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29TL-01LG000/KEC29TL-01LG000_3.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2823",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "마리나",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 17000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/59521af223f9f4277b404c8e3472dfe2.jpg",
+    "specs": {
+      "capacity": 4,
+      "innerMaterial": "폴리에스테르",
+      "waterproofRating": 3000
+    },
+    "_productNo": "2823",
+    "_detailUrl": "https://www.kovea.co.kr/product/마리나/2823/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9TO-04ZZ000/KECX9TO-04ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9TO-04ZZ000/KECX9TO-04ZZ000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2813",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "고스트 쉘터",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 11000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/7f530d32ffd9f5b46a9823887b9c7a35.jpg",
+    "specs": {
+      "capacity": 4,
+      "flyMaterial": "나일론",
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "duralumin",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2813",
+    "_detailUrl": "https://www.kovea.co.kr/product/고스트-쉘터/2813/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9TW-01ZZ000/KECY9TW-01ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9TW-01ZZ000/KECY9TW-01ZZ000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2800",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "X코어N (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2900,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/a7f3796f39b96c1ffca638a00a5f3348.jpg",
+    "specs": {
+      "flyMaterial": "나일론",
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "duralumin"
+    },
+    "_productNo": "2800",
+    "_detailUrl": "https://www.kovea.co.kr/product/x코어n-블랙/2800/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9TL-02BK000/KECX9TL-02BK000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9TL-02BK000/KECX9TL-02BK000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2786",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "와일드 델타 샌드 쉘터형 캠핑 텐트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 17500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/562143e4f6bfa616ab67eaf981588c91.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "duralumin",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2786",
+    "_detailUrl": "https://www.kovea.co.kr/product/와일드-델타-샌드-쉘터형-캠핑-텐트/2786/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_04/KEC19TW-01SD000/KEC19TW-01SD000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2793",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "레트로 파빌리온",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/ce1e945f94c9c1a514e7f792267c64ed.jpg",
+    "specs": {},
+    "_productNo": "2793",
+    "_detailUrl": "https://www.kovea.co.kr/product/레트로-파빌리온/2793/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9TP-01ZZ000/KECY9TP-01ZZ000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2798",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "몬타나 (아이보리)",
+    "color": "",
+    "colorKorean": "아이보리",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 3200,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/cf9e113c71acfad6f6e3c7de718da40f.jpg",
+    "specs": {
+      "capacity": 2,
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "aluminum",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2798",
+    "_detailUrl": "https://www.kovea.co.kr/product/몬타나-아이보리/2798/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECW9TL-05IV000/KECW9TL-05IV000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECW9TL-05IV000/KECW9TL-05IV000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2836",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "고스트 타이탄 (탄)",
+    "color": "",
+    "colorKorean": "탄",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 20500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/98257556789a296da203912bd99afcc9.jpg",
+    "specs": {
+      "flyMaterial": "나일론",
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "duralumin",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2836",
+    "_detailUrl": "https://www.kovea.co.kr/product/고스트-타이탄-탄/2836/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9TO-07TN000/KECP9TO-07TN000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2791",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "와우 패밀리 골드",
+    "color": "",
+    "colorKorean": "골드",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 5500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/0dd214bdb7177753b5a43771eead782b.png",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "fiberglass",
+      "waterproofRating": 3000
+    },
+    "_productNo": "2791",
+    "_detailUrl": "https://www.kovea.co.kr/product/와우-패밀리-골드/2791/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9TI-04GO000/KECP9TI-04GO000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2914",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "에이콘",
+    "color": "",
+    "colorKorean": "샌드",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 6200,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/697f21ab94fcf8d12beebe6049b2dfc0.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "duralumin",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2914",
+    "_detailUrl": "https://www.kovea.co.kr/product/에이콘/2914/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECQ9TZ-01SD000/KECQ9TZ-01SD000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2824",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "네스트 W (카키)",
+    "color": "",
+    "colorKorean": "카키",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 21000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/468b6320fcfbb48306c05191d575a157.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "aluminum",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2824",
+    "_detailUrl": "https://www.kovea.co.kr/product/네스트-w-카키/2824/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9TO-02KH000/KECP9TO-02KH000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2790",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "와우 쉐이드 L",
+    "color": "",
+    "colorKorean": "",
+    "size": "L",
+    "sizeKorean": "라지",
+    "weight": 3600,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/f726f5c1f42c3ce5a81dfe8056c84a2b.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "fiberglass",
+      "waterproofRating": 1200
+    },
+    "_productNo": "2790",
+    "_detailUrl": "https://www.kovea.co.kr/product/와우-쉐이드-l/2790/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9TI-02ZZ000/KECX9TI-02ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9TI-02ZZ000/KECX9TI-02ZZ000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2067",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "고스트 쉘터 베스티블",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/ace2ec1b6eadfdc162195577b292d0e5.jpg",
+    "specs": {
+      "flyMaterial": "나일론",
+      "poleMaterial": "duralumin",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2067",
+    "_detailUrl": "https://www.kovea.co.kr/product/고스트-쉘터-베스티블/2067/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9TZ-01ZZ000/KECO9TZ-01ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9TZ-01ZZ000/KECO9TZ-01ZZ000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2810",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "에버닌 제리 (카키)",
+    "color": "",
+    "colorKorean": "카키",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 9000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/e3cd2cc205bf4649020f08976b2e4f95.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "aluminum",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2810",
+    "_detailUrl": "https://www.kovea.co.kr/product/에버닌-제리-카키/2810/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9TW-04KH000/KECP9TW-04KH000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2806",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "투어링 카쉘터 M2",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 11400,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/257a3dc75a664928eff0fb3626136861.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "fiberglass",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2806",
+    "_detailUrl": "https://www.kovea.co.kr/product/투어링-카쉘터-m2/2806/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9TW-04ZZ000/KECY9TW-04ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9TW-04ZZ000/KECY9TW-04ZZ000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2812",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "에버닌 메리 (베이지)",
+    "color": "",
+    "colorKorean": "베이지",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 11000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/6ef282c685508841f9ddc031cfa85da5.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "aluminum",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2812",
+    "_detailUrl": "https://www.kovea.co.kr/product/에버닌-메리-베이지/2812/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9TW-05BE000/KECP9TW-05BE000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2784",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "팝업 코트 텐트 1인용 원터치 캠핑 텐트",
+    "color": "",
+    "colorKorean": "카키",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/a7b2957879940bf99b66fca95df3e42f.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "fiberglass",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2784",
+    "_detailUrl": "https://www.kovea.co.kr/product/팝업-코트-텐트-1인용-원터치-캠핑-텐트/2784/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19TI-01KH000/KEC19TI-01KH000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19TI-01KH000/KEC19TI-01KH000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_3123",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "백패킹텐트 코어 라이트 TP2 2인용 경량텐트",
+    "color": "",
+    "colorKorean": "그레이",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2400,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/68e30ef58c6429cd04d3078d3d4f0f72.jpg",
+    "specs": {
+      "flyMaterial": "나일론",
+      "poleMaterial": "duralumin",
+      "waterproofRating": 3000
+    },
+    "_productNo": "3123",
+    "_detailUrl": "https://www.kovea.co.kr/product/백패킹텐트-코어-라이트-tp2-2인용-경량텐트/3123/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29TL-02GR000/KEC29TL-02GR.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2811",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "에버닌 제리 (베이지)",
+    "color": "",
+    "colorKorean": "베이지",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 9000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/453147e087d5ce8d2423e03ef5b732a1.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "aluminum",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2811",
+    "_detailUrl": "https://www.kovea.co.kr/product/에버닌-제리-베이지/2811/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9TW-04BE000/KECP9TW-04BE000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_3089",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "아웃백 시그니처",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 29000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202601/361b7c94e749a30c64e3342ffe21e2f0.png",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "aluminum",
+      "waterproofRating": 3000
+    },
+    "_productNo": "3089",
+    "_detailUrl": "https://www.kovea.co.kr/product/아웃백-시그니처/3089/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/SIGNATURE.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9TO-09ZZ000/KECY9TO-09ZZ000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2796",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "베이스 허브 돔 2P (그레이카키)",
+    "color": "",
+    "colorKorean": "그레이카키",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 4000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/f09e61397430547c506e839e746dad14.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "duralumin",
+      "waterproofRating": 3000
+    },
+    "_productNo": "2796",
+    "_detailUrl": "https://www.kovea.co.kr/product/베이스-허브-돔-2p-그레이카키/2796/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/KECQ9TL-01GK000/KECQ9TL-01GK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2797",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "베이스 허브 돔 2P EX (그레이카키)",
+    "color": "",
+    "colorKorean": "그레이카키",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 4700,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/9cb423c3002a8d7f3a1bb2523a73b865.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "duralumin",
+      "waterproofRating": 3000
+    },
+    "_productNo": "2797",
+    "_detailUrl": "https://www.kovea.co.kr/product/베이스-허브-돔-2p-ex-그레이카키/2797/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/KECQ9TL-02GK000/KECQ9TL-02GK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=588"
+  },
+  {
+    "groupId": "kovea_2776",
+    "category": "tarp",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "와일드 임팩트퓨전 헥사 타프 캠핑 그늘막",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2800,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/c127762c4a63b3908aef2b5432fd40d9.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "waterproofRating": 5000
+    },
+    "_productNo": "2776",
+    "_detailUrl": "https://www.kovea.co.kr/product/와일드-임팩트퓨전-헥사-타프-캠핑-그늘막/2776/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19TT-01BK000/KEC19TT-01BK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=602"
+  },
+  {
+    "groupId": "kovea_3057",
+    "category": "tarp",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "랜드 렉타타프",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 8500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202511/e596767932b0488b8fe47ed365195c5d.png",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "waterproofRating": 3000
+    },
+    "_productNo": "3057",
+    "_detailUrl": "https://www.kovea.co.kr/product/랜드-렉타타프/3057/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECU9TT-01ZZ000/KECU9TT-01ZZ000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=602"
+  },
+  {
+    "groupId": "kovea_2944",
+    "category": "tarp",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "라이브 렉타가든",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/76a7d89e8a7852e72b17af89d1c8a776.jpg",
+    "specs": {},
+    "_productNo": "2944",
+    "_detailUrl": "https://www.kovea.co.kr/product/라이브-렉타가든/2944/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECV9TW-02ZZ000/KECV9TW-02ZZ000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=602"
+  },
+  {
+    "groupId": "kovea_2782",
+    "category": "tarp",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "렉타가든 플러스 II",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 15000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/3aa2cfe57a3418eac5ae1c9418b353aa.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "waterproofRating": 3000
+    },
+    "_productNo": "2782",
+    "_detailUrl": "https://www.kovea.co.kr/product/렉타가든-플러스-ii/2782/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/NNEditor/20250923/KECX9TW-02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=602"
+  },
+  {
+    "groupId": "kovea_1624",
+    "category": "tarp",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "렉타 타프 와이드 스크린 Ⅱ",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/6c070b9d5aa19f7d29a999681d092b7e.jpg",
+    "specs": {},
+    "_productNo": "1624",
+    "_detailUrl": "https://www.kovea.co.kr/product/렉타-타프-와이드-스크린/1624/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/kovea/199db1e948d8f7c5de4d8960fc97f5a2.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=602"
+  },
+  {
+    "groupId": "kovea_2778",
+    "category": "tarp",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "써클타프",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/0f60a0113978dac7f5047247b3cb93b8.jpg",
+    "specs": {},
+    "_productNo": "2778",
+    "_detailUrl": "https://www.kovea.co.kr/product/써클타프/2778/",
+    "_specImages": [],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=602"
+  },
+  {
+    "groupId": "kovea_2780",
+    "category": "tarp",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "미니타프 (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/af20663b58de396362d7628cb7c87d96.jpg",
+    "specs": {},
+    "_productNo": "2780",
+    "_detailUrl": "https://www.kovea.co.kr/product/미니타프-블랙/2780/",
+    "_specImages": [],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=602"
+  },
+  {
+    "groupId": "kovea_2779",
+    "category": "tarp",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "미니타프 (탄)",
+    "color": "",
+    "colorKorean": "탄",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2800,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/739d95661d063500b9cb55ddeb6e16ed.png",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2779",
+    "_detailUrl": "https://www.kovea.co.kr/product/미니타프-탄/2779/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECW9TT-03ZZ000/KECW9TT-03ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECW9TT-03ZZ000/KECW9TT-03ZZ000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=602"
+  },
+  {
+    "groupId": "kovea_2977",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "2웨이 플랫 체어 (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 3300,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/b9144719328f4a01b4e496ec3d4e8e48.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 100,
+      "packedSize": "51x42x75cm"
+    },
+    "_productNo": "2977",
+    "_detailUrl": "https://www.kovea.co.kr/product/2웨이-플랫-체어-블랙/2977/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECW9CS-04BK000/KECW9CS-04BK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2867",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "와일드 H.A.F. 체어 (카키)",
+    "color": "",
+    "colorKorean": "카키",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1450,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202510/9d72a3179563834b88d226a5288344aa.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "15x14x41cm",
+      "maxLoad": 120
+    },
+    "_productNo": "2867",
+    "_detailUrl": "https://www.kovea.co.kr/product/와일드-haf-체어-카키/2867/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9CA-01/KECP9CA-01_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_3062",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "라이트 체어 X 캠핑 초경량 의자 (라이트그레이)",
+    "color": "",
+    "colorKorean": "라이트그레이",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202601/51e07b823069bc407087ee7d00c5151a.jpg",
+    "specs": {
+      "material": "나일론",
+      "packedSize": "56x48x69cm",
+      "maxLoad": 100
+    },
+    "_productNo": "3062",
+    "_detailUrl": "https://www.kovea.co.kr/product/라이트-체어-x-캠핑-초경량-의자/3062/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29CA-01/KEC29CA-01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_3062",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "라이트 체어 X 캠핑 초경량 의자 (모스)",
+    "color": "",
+    "colorKorean": "모스",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202601/51e07b823069bc407087ee7d00c5151a.jpg",
+    "specs": {
+      "material": "나일론",
+      "packedSize": "56x48x69cm",
+      "maxLoad": 100
+    },
+    "_productNo": "3062",
+    "_detailUrl": "https://www.kovea.co.kr/product/라이트-체어-x-캠핑-초경량-의자/3062/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29CA-01/KEC29CA-01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_3048",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "임팩트 퓨전 캠핑 코트 야전침대",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 4300,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202511/481cbac3505e6e597a1e0bd19fa45ab1.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "20x60cm",
+      "maxLoad": 120
+    },
+    "_productNo": "3048",
+    "_detailUrl": "https://www.kovea.co.kr/product/임팩트-퓨전-캠핑-코트-야전침대/3048/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19CC-02BK000/P0000EEU_1.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19CC-02BK000/P0000EEU_3.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2846",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "리클라이너 릴렉스 캠핑 의자 접이식 체어 모스그린",
+    "color": "",
+    "colorKorean": "모스그린",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 4300,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/f916da2f80b54e13155fab837384b2c2.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "62x71x98cm",
+      "maxLoad": 120
+    },
+    "_productNo": "2846",
+    "_detailUrl": "https://www.kovea.co.kr/product/리클라이너-릴렉스-캠핑-의자-접이식-체어-모스그린/2846/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_04/KEC19CA-01MS000/KEC19CA-01MS000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_04/KEC19CA-01MS000/KEC19CA-01MS000_03.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2837",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "와일드 레인저 에어 소파 캠핑용 소파",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 7700,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/f08de601140243c085d66999d76a02f8.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "170x81x70cm",
+      "maxLoad": 250
+    },
+    "_productNo": "2837",
+    "_detailUrl": "https://www.kovea.co.kr/product/와일드-레인저-에어-소파-캠핑용-소파/2837/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19CF-02KC000/KEC19CF-02KC000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2856",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "벨로우드 플랫체어 (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 4000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202510/fb7d7e4d66dfac202012d34c88c19735.png",
+    "specs": {
+      "maxLoad": 100,
+      "packedSize": "53x58x65cm"
+    },
+    "_productNo": "2856",
+    "_detailUrl": "https://www.kovea.co.kr/product/벨로우드-플랫체어-블랙/2856/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9CW-01BK000/KECY9CW-01BK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2847",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "리클라이너 릴렉스 캠핑 의자 접이식 체어 블랙",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 4300,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/32edb5f082c9ed16c66f0c20e6074974.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "62x71x98cm",
+      "maxLoad": 120
+    },
+    "_productNo": "2847",
+    "_detailUrl": "https://www.kovea.co.kr/product/리클라이너-릴렉스-캠핑-의자-접이식-체어-블랙/2847/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_04/KEC19CA-01BK000/KEC19CA-01BK000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_04/KEC19CA-01BK000/KEC19CA-01BK000_03.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2845",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "임팩트 퓨전 캠핑 의자 접이식 체어",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 3200,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/d238de474f546f531fe05c70f1d037e9.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "59x56x68cm",
+      "maxLoad": 120
+    },
+    "_productNo": "2845",
+    "_detailUrl": "https://www.kovea.co.kr/product/임팩트-퓨전-캠핑-의자-접이식-체어/2845/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_06/KEC19CA-03BK000/KEC19CA-03BK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2831",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "폴집 BBQ 체어 카키 캠핑 의자 접이식",
+    "color": "",
+    "colorKorean": "카키",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 300,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/b8490767f6b6142968bdd4ad6fb321d9.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "23x27x27cm",
+      "maxLoad": 75
+    },
+    "_productNo": "2831",
+    "_detailUrl": "https://www.kovea.co.kr/product/폴집-bbq-체어-카키-캠핑-의자-접이식/2831/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19CA-04KH000/KEC19CA-04KH000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2855",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "벨로우드 플랫체어 (아이보리)",
+    "color": "",
+    "colorKorean": "아이보리",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 4000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202510/980fa68a0f4ecc6b2d34120b13a57da3.png",
+    "specs": {
+      "maxLoad": 100,
+      "packedSize": "53x58x65cm"
+    },
+    "_productNo": "2855",
+    "_detailUrl": "https://www.kovea.co.kr/product/벨로우드-플랫체어-아이보리/2855/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9CW-01IV000/KECY9CW-01IV000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2976",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "미니 BBQ 체어 세트 Ⅱ (민트)",
+    "color": "",
+    "colorKorean": "민트",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/52cd6a779e3e3037eabd6acd4ec8b07f.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 100,
+      "packedSize": "36x40x28cm"
+    },
+    "_productNo": "2976",
+    "_detailUrl": "https://www.kovea.co.kr/product/미니-bbq-체어-세트-민트/2976/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECS9CS-01/KECS9CS-01_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECS9CS-01/KECS9CS-01_02.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECS9CS-01/KECS9CS-01_03.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2868",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "와일드 H.A.F. 체어 (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1450,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202510/9133550606c9f6ff79f796fefaa09a0d.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "15x14x41cm",
+      "maxLoad": 120
+    },
+    "_productNo": "2868",
+    "_detailUrl": "https://www.kovea.co.kr/product/와일드-haf-체어-블랙/2868/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9CA-01/KECP9CA-01_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_3074",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "리클라이너 그라운드 체어 플러스2 캠핑 의자 (베이지)",
+    "color": "",
+    "colorKorean": "베이지",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1700,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202602/967652910254aab0baf0352a10831b03.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 80
+    },
+    "_productNo": "3074",
+    "_detailUrl": "https://www.kovea.co.kr/product/리클라이너-그라운드-체어-플러스2-캠핑-의자/3074/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29CA-02/KEC29CA-02-01.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29CA-02/KEC29CA-02-03.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_3074",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "리클라이너 그라운드 체어 플러스2 캠핑 의자 (모스)",
+    "color": "",
+    "colorKorean": "모스",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1700,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202602/967652910254aab0baf0352a10831b03.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 80
+    },
+    "_productNo": "3074",
+    "_detailUrl": "https://www.kovea.co.kr/product/리클라이너-그라운드-체어-플러스2-캠핑-의자/3074/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29CA-02/KEC29CA-02-01.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29CA-02/KEC29CA-02-03.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2870",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "알파인 체어 IV",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 300,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/be4e68a75386e93ec0b2c4fc2e0570ed.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 80,
+      "packedSize": "24x23x25cm"
+    },
+    "_productNo": "2870",
+    "_detailUrl": "https://www.kovea.co.kr/product/알파인-체어-iv/2870/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9CA-07ZZ000/KECX9CA-07ZZ000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2848",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "듀플렉스 캠핑 의자 접이식 체어",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/2c6248b5ba8c2ac969e8d72bcc677e0b.jpg",
+    "specs": {},
+    "_productNo": "2848",
+    "_detailUrl": "https://www.kovea.co.kr/product/듀플렉스-캠핑-의자-접이식-체어/2848/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/NNEditor/20251210/01.DUPLEX20CHAIR_250313.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2879",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "WS 캔버스 롱 체어 (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 4100,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/4dadc2b0071641ed00e6550986d93501.jpg",
+    "specs": {
+      "maxLoad": 100,
+      "packedSize": "94x57x78cm"
+    },
+    "_productNo": "2879",
+    "_detailUrl": "https://www.kovea.co.kr/product/ws-캔버스-롱-체어-블랙/2879/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9CA-08BK000/KECO9CA-08BK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_3008",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "알파인 업 체어 V 경량 캠핑 의자",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 400,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/b2a9cb723f9e1dca5c9956204beb137d.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 80
+    },
+    "_productNo": "3008",
+    "_detailUrl": "https://www.kovea.co.kr/product/알파인-업-체어-v-경량-캠핑-의자/3008/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19CA-05BK000/KEC19CA-05BK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2874",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "WS 패밀리 벤치체어 (그레이)",
+    "color": "",
+    "colorKorean": "그레이",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 6200,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/1c69a09c3c7dbaa00fc25dd4946f8089.png",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "103x60x74cm"
+    },
+    "_productNo": "2874",
+    "_detailUrl": "https://www.kovea.co.kr/product/ws-패밀리-벤치체어-그레이/2874/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9CA-02GR000/KECX9CA-02GR000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9CA-02GR000/KECX9CA-02GR000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2975",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "미니 BBQ 체어 세트 Ⅱ (오렌지)",
+    "color": "",
+    "colorKorean": "오렌지",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/a695a1368ae00f5c6ea0e3d60dc8182f.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 100,
+      "packedSize": "36x40x28cm"
+    },
+    "_productNo": "2975",
+    "_detailUrl": "https://www.kovea.co.kr/product/미니-bbq-체어-세트-오렌지/2975/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECS9CS-01/KECS9CS-01_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECS9CS-01/KECS9CS-01_02.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECS9CS-01/KECS9CS-01_03.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2864",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "필드 캡틴 체어 L (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "L",
+    "sizeKorean": "라지",
+    "weight": 3500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/a1eb7124385d8d754e8c4c6ec4b7d379.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 100,
+      "packedSize": "59x82cm"
+    },
+    "_productNo": "2864",
+    "_detailUrl": "https://www.kovea.co.kr/product/필드-캡틴-체어-l-블랙/2864/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9CA-10BK000/KECO9CA-10BK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2331",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "에버닌 미뇽 체어 (아이보리)",
+    "color": "",
+    "colorKorean": "아이보리",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 3200,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/1a4009500bd9ce8440d95dbff8280ce6.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "60x61x73cm",
+      "maxLoad": 100
+    },
+    "_productNo": "2331",
+    "_detailUrl": "https://www.kovea.co.kr/product/에버닌-미뇽-체어/2331/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9CA-05/KECP9CA-05_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2861",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "로우 슬림 체어 (썬셋레드)",
+    "color": "",
+    "colorKorean": "썬셋레드",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 3600,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/828908b983bfe8a05f60e096b09cb949.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "53x53x79cm"
+    },
+    "_productNo": "2861",
+    "_detailUrl": "https://www.kovea.co.kr/product/로우-슬림-체어-썬셋레드/2861/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECW9CS-01SU000/KECW9CS-01SU000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECW9CS-01SU000/KECW9CS-01SU000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2844",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "에어어댑트 체어 라이트그레이",
+    "color": "",
+    "colorKorean": "라이트그레이",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 800,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/7205b4f7e7521c860d704de4865769b0.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "53x37x38cm",
+      "maxLoad": 120
+    },
+    "_productNo": "2844",
+    "_detailUrl": "https://www.kovea.co.kr/product/에어어댑트-체어-라이트그레이/2844/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECQ9CA-03LG000/KECQ9CA-03LG000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2843",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "에어어댑트 체어 블랙",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 800,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/1aec581af0683fb0c2cf65d0656aad78.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "53x37x38cm",
+      "maxLoad": 120
+    },
+    "_productNo": "2843",
+    "_detailUrl": "https://www.kovea.co.kr/product/에어어댑트-체어-블랙/2843/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECQ9CA-03BK000/KECQ9CA-03BK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2873",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "데크체어",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 3000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/34b55385f4e2df3b653f9a5f3e991069.png",
+    "specs": {
+      "material": "폴리에스테르"
+    },
+    "_productNo": "2873",
+    "_detailUrl": "https://www.kovea.co.kr/product/데크체어/2873/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9CA-03ZZ000/KECX9CA-03ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9CA-03ZZ000/KECX9CA-03ZZ000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2880",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "코베아 WS 릴렉스 체어 플러스 (카키)",
+    "color": "",
+    "colorKorean": "카키",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/6f1743a1969d83d7d266d9e0fa432caa.png",
+    "specs": {},
+    "_productNo": "2880",
+    "_detailUrl": "https://www.kovea.co.kr/product/코베아-ws-릴렉스-체어-플러스-카키/2880/",
+    "_specImages": [],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2878",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "WS 캔버스 롱 체어 (아이보리)",
+    "color": "",
+    "colorKorean": "아이보리",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 4100,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/da52cafdc21c24b9d362c983d78f0b57.jpg",
+    "specs": {
+      "maxLoad": 100,
+      "packedSize": "94x57x78cm"
+    },
+    "_productNo": "2878",
+    "_detailUrl": "https://www.kovea.co.kr/product/ws-캔버스-롱-체어-아이보리/2878/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9CA-08IV000/KECO9CA-08IV000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2863",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "필드 캡틴 체어 L (그린)",
+    "color": "",
+    "colorKorean": "그린",
+    "size": "L",
+    "sizeKorean": "라지",
+    "weight": 3500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/5633896d7533133dc67037e0350fe5b4.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 100,
+      "packedSize": "59x82cm"
+    },
+    "_productNo": "2863",
+    "_detailUrl": "https://www.kovea.co.kr/product/필드-캡틴-체어-l-그린/2863/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9CA-10GN000/KECO9CA-10GN000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_3063",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "쿼드 펫 코트 캠핑 반려동물 침대",
+    "color": "",
+    "colorKorean": "샌드",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 3000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/06ccb15519cd51d2bb0e2e24c95e2a07.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "16x16x63cm",
+      "maxLoad": 30
+    },
+    "_productNo": "3063",
+    "_detailUrl": "https://www.kovea.co.kr/product/쿼드-펫-코트-캠핑-반려동물-침대/3063/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29CC-01SD000/KEC29CC-01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2833",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "미니마스터 체어 IV 경량 캠핑 의자 그린",
+    "color": "",
+    "colorKorean": "그린",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1200,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/8d0b9fbc7bf691d8700ee473fd95c5ad.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "44x37x54cm",
+      "maxLoad": 80
+    },
+    "_productNo": "2833",
+    "_detailUrl": "https://www.kovea.co.kr/product/미니마스터-체어-iv-경량-캠핑-의자-그린/2833/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19CA-02GN000/KEC19CA-02GN000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2876",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "WS 캔버스 체어 (아이보리)",
+    "color": "",
+    "colorKorean": "아이보리",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 3100,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202510/68c724b4e774b3cda463de970e65ced6.png",
+    "specs": {
+      "maxLoad": 100,
+      "packedSize": "80x54x70cm"
+    },
+    "_productNo": "2876",
+    "_detailUrl": "https://www.kovea.co.kr/product/ws-캔버스-체어-아이보리/2876/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9CA-01IV000/KECX9CA-01IV000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2860",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "스틸메쉬 BBQ 체어세트 (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2100,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/91a037f5cbd91516458ee2c4f80e2747.png",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 80,
+      "packedSize": "35x34x33cm"
+    },
+    "_productNo": "2860",
+    "_detailUrl": "https://www.kovea.co.kr/product/스틸메쉬-bbq-체어세트-블랙/2860/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9CS-01BK000/KECP9CS-01BK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2875",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "WS 캔버스 체어 (레드)",
+    "color": "",
+    "colorKorean": "레드",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 3100,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202510/8ab1bec8f31a0da6a045e843017423a0.png",
+    "specs": {
+      "maxLoad": 100,
+      "packedSize": "80x54x70cm"
+    },
+    "_productNo": "2875",
+    "_detailUrl": "https://www.kovea.co.kr/product/ws-캔버스-체어-레드/2875/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9CA-01BK000/KECX9CA-01BK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2858",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "하이백 체어 Ⅱ (민트)",
+    "color": "",
+    "colorKorean": "민트",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 3000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/c8adef9ad64e575915b85234d8e8a01d.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 100,
+      "packedSize": "81x50x91cm"
+    },
+    "_productNo": "2858",
+    "_detailUrl": "https://www.kovea.co.kr/product/하이백-체어-민트/2858/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECU9CS-02MT000/KECU9CS-02MT000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECU9CS-02MT000/KECU9CS-02MT000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2859",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "스틸 메쉬 원 액션 체어 (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2700,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/09311850c223f8769f9e136421d73a5c.png",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 100,
+      "packedSize": "11x15x86cm"
+    },
+    "_productNo": "2859",
+    "_detailUrl": "https://www.kovea.co.kr/product/스틸-메쉬-원-액션-체어-블랙/2859/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9CS-01BK000/KECO9CS-01BK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_3073",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "포터블 체어 040 플러스 캠핑 의자 (모스)",
+    "color": "",
+    "colorKorean": "모스",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1800,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/5dd156e6d60d2ca1efb16a2d63aea7f0.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "39x38x57cm",
+      "maxLoad": 100
+    },
+    "_productNo": "3073",
+    "_detailUrl": "https://www.kovea.co.kr/product/포터블-체어-040-플러스-캠핑-의자/3073/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29CS-02/KEC29CS-02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_3073",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "포터블 체어 040 플러스 캠핑 의자 (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1800,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/5dd156e6d60d2ca1efb16a2d63aea7f0.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "39x38x57cm",
+      "maxLoad": 100
+    },
+    "_productNo": "3073",
+    "_detailUrl": "https://www.kovea.co.kr/product/포터블-체어-040-플러스-캠핑-의자/3073/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29CS-02/KEC29CS-02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_3073",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "포터블 체어 040 플러스 캠핑 의자 (샌드)",
+    "color": "",
+    "colorKorean": "샌드",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1800,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/5dd156e6d60d2ca1efb16a2d63aea7f0.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "39x38x57cm",
+      "maxLoad": 100
+    },
+    "_productNo": "3073",
+    "_detailUrl": "https://www.kovea.co.kr/product/포터블-체어-040-플러스-캠핑-의자/3073/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29CS-02/KEC29CS-02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2857",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "하이백 체어 Ⅱ (썬셋레드)",
+    "color": "",
+    "colorKorean": "썬셋레드",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 3000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/068ded94bdf4909a3f4d3051268d1720.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 100,
+      "packedSize": "81x50x91cm"
+    },
+    "_productNo": "2857",
+    "_detailUrl": "https://www.kovea.co.kr/product/하이백-체어-썬셋레드/2857/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECU9CS-02SU000/KECU9CS-02SU000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECU9CS-02SU000/KECU9CS-02SU000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_3075",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "컴피 릴렉스 롱 체어 (카키)",
+    "color": "",
+    "colorKorean": "카키",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 3400,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/f722f38b9b6a4d20f3259a30e43df705.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "59x73x99cm",
+      "maxLoad": 100
+    },
+    "_productNo": "3075",
+    "_detailUrl": "https://www.kovea.co.kr/product/컴피-릴렉스-롱-체어/3075/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29CA-04/KEC29CA-04.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_3075",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "컴피 릴렉스 롱 체어 (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 3400,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/f722f38b9b6a4d20f3259a30e43df705.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "59x73x99cm",
+      "maxLoad": 100
+    },
+    "_productNo": "3075",
+    "_detailUrl": "https://www.kovea.co.kr/product/컴피-릴렉스-롱-체어/3075/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29CA-04/KEC29CA-04.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_3158",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "그라운드 체어 040 플러스 블랙/샌드 (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 750,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202606/9db16f709acf2c26003e703c30ab500c.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "40x40x40cm",
+      "maxLoad": 80
+    },
+    "_productNo": "3158",
+    "_detailUrl": "https://www.kovea.co.kr/product/그라운드-체어-040-플러스-블랙샌드/3158/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29CF-01/KEC29CF_01_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29CF-01/KEC29CF_01_3.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_3158",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "그라운드 체어 040 플러스 블랙/샌드 (샌드)",
+    "color": "",
+    "colorKorean": "샌드",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 750,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202606/9db16f709acf2c26003e703c30ab500c.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "40x40x40cm",
+      "maxLoad": 80
+    },
+    "_productNo": "3158",
+    "_detailUrl": "https://www.kovea.co.kr/product/그라운드-체어-040-플러스-블랙샌드/3158/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29CF-01/KEC29CF_01_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29CF-01/KEC29CF_01_3.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=607"
+  },
+  {
+    "groupId": "kovea_2904",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "벨로우드 행어",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 3500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/f3b7ddf002475a7753a6e08615c42da1.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 15,
+      "packedSize": "100x60x100cm"
+    },
+    "_productNo": "2904",
+    "_detailUrl": "https://www.kovea.co.kr/product/벨로우드-행어/2904/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9FR-02ZZ000/KECY9FR-02ZZ000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_2967",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "WS 롤 테이블 M",
+    "color": "",
+    "colorKorean": "",
+    "size": "M",
+    "sizeKorean": "미디엄",
+    "weight": 5000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202510/256cda67b49ea7fadad0f4be8ccf1e74.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 30,
+      "packedSize": "68x28x13cm"
+    },
+    "_productNo": "2967",
+    "_detailUrl": "https://www.kovea.co.kr/product/ws-롤-테이블-m/2967/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9FA-01ZZ000/KECO9FA-01ZZ000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_3002",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "듀플렉스 IGT 캠핑 테이블 확장형",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 5500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/b5e3edae74ebbdf660c00c5f903d94e2.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 30
+    },
+    "_productNo": "3002",
+    "_detailUrl": "https://www.kovea.co.kr/product/듀플렉스-igt-캠핑-테이블-확장형/3002/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19FA-04BK000/KEC19FA-04BK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_3003",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "와일드 STS 캠핑 테이블 경량 접이식",
+    "color": "",
+    "colorKorean": "실버",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 15500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/638e4b733b2c6a37622691529a17e2b4.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "108x36x40cm",
+      "maxLoad": 20
+    },
+    "_productNo": "3003",
+    "_detailUrl": "https://www.kovea.co.kr/product/와일드-sts-캠핑-테이블-경량-접이식/3003/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_06/KEC19FA-05S7000/KEC19FA-05S7000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_3012",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "벨로우드 롤 테이블 M",
+    "color": "",
+    "colorKorean": "",
+    "size": "M",
+    "sizeKorean": "미디엄",
+    "weight": 9500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/5971498e08a2b6a616815cf7ef35bbfb.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 30,
+      "packedSize": "90x60x45cm"
+    },
+    "_productNo": "3012",
+    "_detailUrl": "https://www.kovea.co.kr/product/벨로우드-롤-테이블-m/3012/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9FR-01ZZ000/KECY9FR-01ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9FR-01ZZ000/KECY9FR-01ZZ000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_3044",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "리플렉트 쉘프 캠핑 테이블 수납 테이블",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202511/9e2d2963b5da6e683144dc09225f19e4.jpg",
+    "specs": {},
+    "_productNo": "3044",
+    "_detailUrl": "https://www.kovea.co.kr/product/리플렉트-쉘프-캠핑-테이블-수납-테이블/3044/",
+    "_specImages": [],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_3004",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "임팩트 퓨전 캠핑 테이블 접이식 테이블",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/17801a75ccb416aab3584df03929c5df.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "58x41x40cm",
+      "maxLoad": 30
+    },
+    "_productNo": "3004",
+    "_detailUrl": "https://www.kovea.co.kr/product/임팩트-퓨전-캠핑-테이블-접이식-테이블/3004/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_04/KEC19FA-03BK000/KEC19FA-03BK000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_04/KEC19FA-03BK000/KEC19FA-03BK000_03.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_2158",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "우드롤테이블 (40주년에디션)",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 11000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/db8450fce7b7eb0bc0e6841d8fd3ec83.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 30,
+      "packedSize": "120x70x45cm"
+    },
+    "_productNo": "2158",
+    "_detailUrl": "https://www.kovea.co.kr/product/우드롤테이블-40주년에디션/2158/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9FR-01K1000/KECO9FR-01K1000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_2966",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "스탠드 테이블",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202511/ea597bbc02ed9c4b9255e1f1bb6c1ec9.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 30
+    },
+    "_productNo": "2966",
+    "_detailUrl": "https://www.kovea.co.kr/product/스탠드-테이블/2966/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECT9FA-04ZZ000/KECT9FA-04ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECT9FA-04ZZ000/KECT9FA-04ZZ000_02.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECT9FA-04ZZ000/KECT9FA-04ZZ000_03.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_3091",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "메쉬 IGT 3폴딩 캠핑 테이블 접이식",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 6800,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202602/0cbf4d5972574719a20f83932e22edb3.jpg",
+    "specs": {
+      "packedSize": "61x41x10cm",
+      "maxLoad": 60
+    },
+    "_productNo": "3091",
+    "_detailUrl": "https://www.kovea.co.kr/product/메쉬-igt-3폴딩-캠핑-테이블-접이식/3091/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29FS-03BK000/KEC29FS-03BK000.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_3076",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "메쉬 폴딩 쉘프2 캠핑 수납 테이블",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 5000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202602/315d79153039acb1c9d37760360a45e8.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 60
+    },
+    "_productNo": "3076",
+    "_detailUrl": "https://www.kovea.co.kr/product/메쉬-폴딩-쉘프2-캠핑-수납-테이블/3076/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29FS-04BK000/KEC29FS-04BK000%26ndash%3B1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29FS-04BK000/KEC29FS-04BK000%26ndash%3B3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29FS-04BK000/KEC29FS-04BK000%26ndash%3B5.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_2905",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "벨로우드 쉘프",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 6000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/d9af3257c47a131d80e4e5648d3bf52e.png",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 30,
+      "packedSize": "60x13x41cm"
+    },
+    "_productNo": "2905",
+    "_detailUrl": "https://www.kovea.co.kr/product/벨로우드-쉘프/2905/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9FR-03ZZ000/KECY9FR-03ZZ000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_2906",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "벨로우드 바스켓",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 3400,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/1fc3c44b6c7074ab67063f8ea8e0fa41.png",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 30,
+      "packedSize": "50x40x50cm"
+    },
+    "_productNo": "2906",
+    "_detailUrl": "https://www.kovea.co.kr/product/벨로우드-바스켓/2906/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9FR-01ZZ000/KECP9FR-01ZZ000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_3056",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "이지 라이트 테이블 (하드탑)",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 970,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202511/db9c381968b002cb15aa47de47f950ec.png",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 30,
+      "packedSize": "11x11x44cm"
+    },
+    "_productNo": "3056",
+    "_detailUrl": "https://www.kovea.co.kr/product/이지-라이트-테이블-하드탑/3056/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9FF-02ZZ000/KECX9FF-02ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9FF-02ZZ000/KECX9FF-02ZZ000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_3078",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "캠프1 하프 플레이트 IGT 캠핑 테이블",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 750,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202602/8ccec36c663a920e320d216302a887d2.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 10
+    },
+    "_productNo": "3078",
+    "_detailUrl": "https://www.kovea.co.kr/product/캠프1-하프-플레이트-igt-캠핑-테이블/3078/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29FS-01BK000/KEC29FS-01BK000.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_3065",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "컴팩트 블랙 캠핑 테이블 접이식",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2100,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/79caa49a78aa1b180b024e1f4f06b3f8.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "52x37x34cm",
+      "maxLoad": 20
+    },
+    "_productNo": "3065",
+    "_detailUrl": "https://www.kovea.co.kr/product/컴팩트-블랙-캠핑-테이블-접이식/3065/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29FA-02BK000/KEC29FA-02BK.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_2897",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "메쉬 윙 멀티 테이블",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 6200,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/aa0d5263e7ad0bc90e49ef63351d3267.png",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 30
+    },
+    "_productNo": "2897",
+    "_detailUrl": "https://www.kovea.co.kr/product/메쉬-윙-멀티-테이블/2897/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9FS-03ZZ000/KECY9FS-03ZZ000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_3028",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "벨로우드 롤 테이블 L",
+    "color": "",
+    "colorKorean": "",
+    "size": "L",
+    "sizeKorean": "라지",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/2c3fa26b4075f072aeb7fe7b23d9ef76.jpg",
+    "specs": {},
+    "_productNo": "3028",
+    "_detailUrl": "https://www.kovea.co.kr/product/벨로우드-롤-테이블-l/3028/",
+    "_specImages": [],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_2901",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "가죽 테이블보 M",
+    "color": "",
+    "colorKorean": "",
+    "size": "M",
+    "sizeKorean": "미디엄",
+    "weight": 430,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/71eeefd04b13f48844ebc99000fb903b.png",
+    "specs": {
+      "packedSize": "80x50cm"
+    },
+    "_productNo": "2901",
+    "_detailUrl": "https://www.kovea.co.kr/product/가죽-테이블보-m/2901/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9JH-02ZZ000/KECX9JH-02ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9JH-02ZZ000/KECX9JH-02ZZ000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_3011",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "데코 테이블 행거",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 180,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/cc5f8a6802cab2f14ef485ef1a950f0d.jpg",
+    "specs": {},
+    "_productNo": "3011",
+    "_detailUrl": "https://www.kovea.co.kr/product/데코-테이블-행거/3011/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECV9FZ-02ZZDXL/KECV9FZ-02ZZDXL_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECV9FZ-02ZZDXL/KECV9FZ-02ZZDXL_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_2891",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "WS 폴딩 테이블 L (브라운)",
+    "color": "",
+    "colorKorean": "브라운",
+    "size": "L",
+    "sizeKorean": "라지",
+    "weight": 5500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/163d8eeba6a55427166a9d6c24c46099.png",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 30
+    },
+    "_productNo": "2891",
+    "_detailUrl": "https://www.kovea.co.kr/product/ws-폴딩-테이블-l-브라운/2891/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9FA-03BW000/KECO9FA-03BW000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_2153",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "WS롤테이블XL",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 6700,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202510/b45aee67b2f1f4f9108cfbbb8459e6d8.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 30,
+      "packedSize": "76x25x15cm"
+    },
+    "_productNo": "2153",
+    "_detailUrl": "https://www.kovea.co.kr/product/ws롤테이블xl/2153/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9FA-06ZZ000/KECY9FA-06ZZ000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_2907",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "이지 라이트테이블",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 640,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/666134802c9d2b209cd15ff0f39e0236.png",
+    "specs": {},
+    "_productNo": "2907",
+    "_detailUrl": "https://www.kovea.co.kr/product/이지-라이트테이블/2907/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9FF-01ZZ000/KECX9FF-01ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9FF-01ZZ000/KECX9FF-01ZZ000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_2900",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "슬림 트윈 스토브 캐리백 챠콜",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 630,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/bfa6f02e9677088a619b91daa6bf508c.jpg",
+    "specs": {
+      "material": "폴리에스테르"
+    },
+    "_productNo": "2900",
+    "_detailUrl": "https://www.kovea.co.kr/product/슬림-트윈-스토브-캐리백-챠콜/2900/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECT9BS-01CH000/KECT9BS-01CH000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECT9BS-01CH000/KECT9BS-01CH000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_1726",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "메쉬 시스템 테이블",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2800,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/a929f4ed2cc25fd1a5991359d77ad26d.jpg",
+    "specs": {
+      "maxLoad": 30
+    },
+    "_productNo": "1726",
+    "_detailUrl": "https://www.kovea.co.kr/product/메쉬-시스템-테이블/1726/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9FS-02ZZ000/KECY9FS-02ZZ000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_3010",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "핸디 테이블 세트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 3600,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202510/daab0d17c5a402ccb00e1b61dace62de.png",
+    "specs": {
+      "packedSize": "76x45x34cm",
+      "maxLoad": 40
+    },
+    "_productNo": "3010",
+    "_detailUrl": "https://www.kovea.co.kr/product/핸디-테이블-세트/3010/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9FA-01ZZ000/KECX9FA-01ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9FA-01ZZ000/KECX9FA-01ZZ000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_2896",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "코베아 메쉬 윙 테이블UP (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2900,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202510/ee9d56847eca8f862c2d0e8f68e315e5.jpg",
+    "specs": {
+      "maxLoad": 5
+    },
+    "_productNo": "2896",
+    "_detailUrl": "https://www.kovea.co.kr/product/코베아-메쉬-윙-테이블up-블랙/2896/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9FS-01BK000/KECP9FS-01BK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_2893",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "2웨이키친테이블Ⅱ L (믹스컬러)",
+    "color": "",
+    "colorKorean": "믹스컬러",
+    "size": "L",
+    "sizeKorean": "라지",
+    "weight": 6300,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/0db5f3b9a1d92448286c48d6c1c2d461.png",
+    "specs": {
+      "maxLoad": 40,
+      "packedSize": "60x48x95cm"
+    },
+    "_productNo": "2893",
+    "_detailUrl": "https://www.kovea.co.kr/product/2웨이키친테이블-l-믹스컬러/2893/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECM9FA-11MX000/KECM9FA-11MX000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_368",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "KMTⅠ테이블캐리백",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 840,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/8f9b3f741e5b3a0cf9aad6f5a9dd2937.jpg",
+    "specs": {},
+    "_productNo": "368",
+    "_detailUrl": "https://www.kovea.co.kr/product/kmt테이블캐리백/368/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/kovea/2cd5af72f2d155b94c0fc1c002bc51cf.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_1346",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "라이트 테이블 S",
+    "color": "",
+    "colorKorean": "",
+    "size": "S",
+    "sizeKorean": "스몰",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/d5381a166c8cae8b312de03251cc658c.jpg",
+    "specs": {},
+    "_productNo": "1346",
+    "_detailUrl": "https://www.kovea.co.kr/product/라이트-테이블-s/1346/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/kovea/3cecf327fb1be8636ed977b2fc03f986.jpg",
+      "https://www.kovea.co.kr/web/upload/kovea/67b5074d66c608850a783b0f5cf51319.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_2899",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "와이드 원 액션테이블 L",
+    "color": "",
+    "colorKorean": "",
+    "size": "L",
+    "sizeKorean": "라지",
+    "weight": 6000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/53fe727fcb8d4a491f63c166eadafb04.png",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 40
+    },
+    "_productNo": "2899",
+    "_detailUrl": "https://www.kovea.co.kr/product/와이드-원-액션테이블-l/2899/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9FA-01ZZ000/KECY9FA-01ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9FA-01ZZ000/KECY9FA-01ZZ000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_2895",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "메쉬 파이어 캠프 테이블",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 7200,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202511/dba20e99fc4a64e8ce138742274ce945.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 30,
+      "packedSize": "92x92x28cm"
+    },
+    "_productNo": "2895",
+    "_detailUrl": "https://www.kovea.co.kr/product/메쉬-파이어-캠프-테이블/2895/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9FS-01ZZ000/KECY9FS-01ZZ000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_2898",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "와이드 원 액션테이블 M",
+    "color": "",
+    "colorKorean": "",
+    "size": "M",
+    "sizeKorean": "미디엄",
+    "weight": 5200,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/9fd6bf1241ffe4c3eabfa4347a5aac3a.png",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 40
+    },
+    "_productNo": "2898",
+    "_detailUrl": "https://www.kovea.co.kr/product/와이드-원-액션테이블-m/2898/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9FA-02ZZ000/KECY9FA-02ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9FA-02ZZ000/KECY9FA-02ZZ000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_3067",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "컴팩트 IGT 쉘프 캠핑 테이블 수납형",
+    "color": "",
+    "colorKorean": "실버",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2600,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/6d1bbbbf8efc56c7349c8d786019b739.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "maxLoad": 10
+    },
+    "_productNo": "3067",
+    "_detailUrl": "https://www.kovea.co.kr/product/컴팩트-igt-쉘프-캠핑-테이블-수납형/3067/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29FA-01S7000/KEC29FA-01S7.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_3077",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "캠프1 원 플레이트 IGT 캠핑 테이블",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1220,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202602/4b9c786ba765dc90700177900080589c.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "36x25x14cm",
+      "maxLoad": 20
+    },
+    "_productNo": "3077",
+    "_detailUrl": "https://www.kovea.co.kr/product/캠프1-원-플레이트-igt-캠핑-테이블/3077/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29FS-02BK000/KEC29FS-02BK000.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_2888",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "모리스&amp;보리스 미니 테이블",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1800,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/b1ebe5b72b5c07cdf99d16fb444d6a65.jpg",
+    "specs": {
+      "maxLoad": 5
+    },
+    "_productNo": "2888",
+    "_detailUrl": "https://www.kovea.co.kr/product/모리스보리스-미니-테이블/2888/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECQ9FA-03KH000/KECQ9FA-03KH000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_2889",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "WS 롤 테이블 L",
+    "color": "",
+    "colorKorean": "",
+    "size": "L",
+    "sizeKorean": "라지",
+    "weight": 5600,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/f1c2d56b2a9ab0e1e25662d189d1818f.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "72x29x15cm",
+      "maxLoad": 30
+    },
+    "_productNo": "2889",
+    "_detailUrl": "https://www.kovea.co.kr/product/ws-롤-테이블-l/2889/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2024/KECQ9FA-02WD000/KECQ9FA-02WD000.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=612"
+  },
+  {
+    "groupId": "kovea_3120",
+    "category": "sleeping_bag",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "스너글 플리스 침낭 500 캠핑 동계 침낭",
+    "color": "",
+    "colorKorean": "샌드",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/15ae0cc4d07fcf456e5860d2f300466c.jpg",
+    "specs": {
+      "fillMaterial": "synthetic",
+      "comfortTemp": 0,
+      "limitTemp": -15
+    },
+    "_productNo": "3120",
+    "_detailUrl": "https://www.kovea.co.kr/product/스너글-플리스-침낭-500-캠핑-동계-침낭/3120/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29SP-01SD000/KEC29SP-01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=641"
+  },
+  {
+    "groupId": "kovea_3119",
+    "category": "sleeping_bag",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "스너글 플리스 침낭 1500 캠핑 겨울 침낭",
+    "color": "",
+    "colorKorean": "샌드",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2900,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/af266a90f350adad3f0a90fc708f678c.jpg",
+    "specs": {
+      "fillMaterial": "synthetic",
+      "comfortTemp": 0,
+      "limitTemp": -15
+    },
+    "_productNo": "3119",
+    "_detailUrl": "https://www.kovea.co.kr/product/스너글-플리스-침낭-1500-캠핑-겨울-침낭/3119/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29SP-02SD000/KEC29SP-02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=641"
+  },
+  {
+    "groupId": "kovea_2702",
+    "category": "sleeping_bag",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "더블 EX",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 5000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202510/cb430855d8d137bfb7308e1975dab8a6.png",
+    "specs": {
+      "fillMaterial": "synthetic",
+      "comfortTemp": 8,
+      "limitTemp": 3
+    },
+    "_productNo": "2702",
+    "_detailUrl": "https://www.kovea.co.kr/product/더블-ex/2702/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECT9SP-01ZZ000/KECT9SP-01ZZ000_01.jpg",
+      "https://www.kovea.co.kr/web/upload/NNEditor/20251110/copy-1762757545-28E1848EE185ACE1848CE185A9E186BC29E1848EE185B5E186B7E18482E185A1E186BCE18489E185B5E1848BE185A1E186AB20copy.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=641"
+  },
+  {
+    "groupId": "kovea_2701",
+    "category": "sleeping_bag",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "더블EX패밀리 (베이지)",
+    "color": "",
+    "colorKorean": "베이지",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 5000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/05abc5d3e091af773722e3883ff49eec.png",
+    "specs": {
+      "fillMaterial": "synthetic",
+      "comfortTemp": 8,
+      "limitTemp": 3
+    },
+    "_productNo": "2701",
+    "_detailUrl": "https://www.kovea.co.kr/product/더블ex패밀리-베이지/2701/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9SP-04BE000/KECP9SP-04BE000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=641"
+  },
+  {
+    "groupId": "kovea_2700",
+    "category": "sleeping_bag",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "크레센트 1800 (딥네이비)",
+    "color": "",
+    "colorKorean": "딥네이비",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 3200,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/7d7cc7f475e15ff85346a0645684ba69.png",
+    "specs": {
+      "fillMaterial": "synthetic",
+      "comfortTemp": 2,
+      "limitTemp": -5
+    },
+    "_productNo": "2700",
+    "_detailUrl": "https://www.kovea.co.kr/product/크레센트-1800-딥네이비/2700/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECQ9SP-01NA000/KECQ9SP-01NA000_01.jpg",
+      "https://www.kovea.co.kr/web/upload/NNEditor/20251110/28E1848EE185ACE1848CE185A9E186BC29E1848EE185B5E186B7E18482E185A1E186BCE18489E185B5E1848BE185A1E186AB20copy.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=641"
+  },
+  {
+    "groupId": "kovea_2698",
+    "category": "sleeping_bag",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "코베아 템플라도 1000 (베이지) 침낭",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/ac629f79be00d4d01c51d319550ebc59.png",
+    "specs": {
+      "comfortTemp": 11,
+      "limitTemp": 6
+    },
+    "_productNo": "2698",
+    "_detailUrl": "https://www.kovea.co.kr/product/코베아-템플라도-1000-베이지-침낭/2698/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/NNEditor/20251110/copy-1762757080-28E1848EE185ACE1848CE185A9E186BC29E1848EE185B5E186B7E18482E185A1E186BCE18489E185B5E1848BE185A1E186AB20copy.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=641"
+  },
+  {
+    "groupId": "kovea_2697",
+    "category": "sleeping_bag",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "코베아 템플라도 1500 (다크그린) 침낭",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2300,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/8ae68c0c2db9d97b40019fbdc3f55a63.png",
+    "specs": {
+      "fillMaterial": "synthetic",
+      "comfortTemp": 11,
+      "limitTemp": 6
+    },
+    "_productNo": "2697",
+    "_detailUrl": "https://www.kovea.co.kr/product/코베아-템플라도-1500-다크그린-침낭/2697/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/NNEditor/20251117/ED859CED948CEB9DBCEB8F84201500.jpg",
+      "https://www.kovea.co.kr/web/upload/NNEditor/20251110/copy-1762757101-28E1848EE185ACE1848CE185A9E186BC29E1848EE185B5E186B7E18482E185A1E186BCE18489E185B5E1848BE185A1E186AB20copy.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=641"
+  },
+  {
+    "groupId": "kovea_2696",
+    "category": "sleeping_bag",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "템플라도 600 (로얄블루)",
+    "color": "",
+    "colorKorean": "로얄블루",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1200,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/dea28f3762cbea875e9bcee7a19fd203.png",
+    "specs": {
+      "fillMaterial": "synthetic",
+      "comfortTemp": 15,
+      "limitTemp": 10
+    },
+    "_productNo": "2696",
+    "_detailUrl": "https://www.kovea.co.kr/product/템플라도-600-로얄블루/2696/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9SP-01RO000/KECP9SP-01RO000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=641"
+  },
+  {
+    "groupId": "kovea_1235",
+    "category": "sleeping_bag",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "리미트 800",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/f317e6d6110f123007cd98275780c5be.jpg",
+    "specs": {
+      "limitTemp": -25,
+      "comfortTemp": -10
+    },
+    "_productNo": "1235",
+    "_detailUrl": "https://www.kovea.co.kr/product/리미트-800/1235/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/kovea/66299dfb8cf927875832b66e5d4a9c1a.jpg",
+      "https://www.kovea.co.kr/web/upload/kovea/2ed75d66760e03a0721cc76ec5f01e71.jpg",
+      "https://www.kovea.co.kr/web/upload/kovea/6cd50f1fedb3f2c1790a97b2e4301ec7.jpg",
+      "https://www.kovea.co.kr/web/upload/NNEditor/20251110/copy-1762757173-28E1848EE185ACE1848CE185A9E186BC29E1848EE185B5E186B7E18482E185A1E186BCE18489E185B5E1848BE185A1E186AB20copy.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=641"
+  },
+  {
+    "groupId": "kovea_3030",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "캠프매트 G200 캠핑 매트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/bc8e25a38f6629eafacae991174388f1.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "openSize": "200x200cm"
+    },
+    "_productNo": "3030",
+    "_detailUrl": "https://www.kovea.co.kr/product/캠프매트-g200-캠핑-매트/3030/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19WF-04GR000/KEC19WF-04GR000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_3029",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "캠프매트 G260 캠핑 매트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1900,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/9f38bd93a8f3232a08b6f81bddb9eb21.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "openSize": "260x200cm"
+    },
+    "_productNo": "3029",
+    "_detailUrl": "https://www.kovea.co.kr/product/캠프매트-g260-캠핑-매트/3029/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19WF-05GR000/KEC19WF-05GR000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_3027",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "캠프매트 G120 캠핑 매트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 730,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/2bc25caf53e8a4f6b20391caac354f9e.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "openSize": "120x200cm"
+    },
+    "_productNo": "3027",
+    "_detailUrl": "https://www.kovea.co.kr/product/캠프매트-g120-캠핑-매트/3027/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19WF-02GR000/KEC19WF-02GR000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_3026",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "캠프매트 G160 캠핑 매트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1100,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/878614cac1715983f7e464f2ed0aeb0c.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "openSize": "160x200cm"
+    },
+    "_productNo": "3026",
+    "_detailUrl": "https://www.kovea.co.kr/product/캠프매트-g160-캠핑-매트/3026/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19WF-03GR000/KEC19WF-03GR000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_3007",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "이중 공간지 에어 매트 40 캠핑 매트",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 8100,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202511/36259760a482632cfd98aad225db115e.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "openSize": "45x25x30cm",
+      "maxLoad": 200
+    },
+    "_productNo": "3007",
+    "_detailUrl": "https://www.kovea.co.kr/product/이중-공간지-에어-매트-40-캠핑-매트/3007/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19WA-02BK000/KEC19WA-02BK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2695",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "캠프매트 120 (탄)",
+    "color": "",
+    "colorKorean": "탄",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 730,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/eccdac037439fa855695d621112c8523.png",
+    "specs": {
+      "openSize": "120x200cm"
+    },
+    "_productNo": "2695",
+    "_detailUrl": "https://www.kovea.co.kr/product/캠프매트-120-탄/2695/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECS9WF-01TN000/KECS9WF-01TN000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2694",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "캠프매트 160 (탄)",
+    "color": "",
+    "colorKorean": "탄",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1100,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/b6855f4d6d2adbe9357ecdb8963a8277.png",
+    "specs": {
+      "openSize": "160x200cm"
+    },
+    "_productNo": "2694",
+    "_detailUrl": "https://www.kovea.co.kr/product/캠프매트-160-탄/2694/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECS9WF-02TN000/KECS9WF-02TN000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2693",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "캠프매트 200 (탄)",
+    "color": "",
+    "colorKorean": "탄",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/15fe91fe46e57bcfdac5e84920e762cc.png",
+    "specs": {
+      "openSize": "197x200cm"
+    },
+    "_productNo": "2693",
+    "_detailUrl": "https://www.kovea.co.kr/product/캠프매트-200-탄/2693/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECR9WF-01TN000/KECR9WF-01TN000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2691",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "멀티 코지 토퍼",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/10dc00f4213f8b103b67363e74a01b34.png",
+    "specs": {},
+    "_productNo": "2691",
+    "_detailUrl": "https://www.kovea.co.kr/product/멀티-코지-토퍼/2691/",
+    "_specImages": [],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2690",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "멀티 쿨링 토퍼",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/2a768f8f53e6c2248dfc56000e3915c1.png",
+    "specs": {},
+    "_productNo": "2690",
+    "_detailUrl": "https://www.kovea.co.kr/product/멀티-쿨링-토퍼/2690/",
+    "_specImages": [],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2689",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "멀티 블랭킷 II 230",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/84ccdb093a8996320181fb14338838dd.png",
+    "specs": {},
+    "_productNo": "2689",
+    "_detailUrl": "https://www.kovea.co.kr/product/멀티-블랭킷-ii-230/2689/",
+    "_specImages": [],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2688",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "코지 블랭킷 라이트 (민트)",
+    "color": "",
+    "colorKorean": "민트",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1700,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/0b6da5a5aab4469053d30465487c641c.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "openSize": "200x180cm"
+    },
+    "_productNo": "2688",
+    "_detailUrl": "https://www.kovea.co.kr/product/코지-블랭킷-라이트-민트/2688/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9WG-02MT000/KECO9WG-02MT000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2687",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "2웨이 자충필로우 047 (샌드)",
+    "color": "",
+    "colorKorean": "샌드",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 370,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/7124936c4181210f571b630359359595.jpg",
+    "specs": {
+      "material": "나일론",
+      "openSize": "12x32cm"
+    },
+    "_productNo": "2687",
+    "_detailUrl": "https://www.kovea.co.kr/product/2웨이-자충필로우-047-샌드/2687/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/KECQ9WP-02SD000/KECQ9WP-02SD000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2685",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "소프트 에어 필로우 035 (그레이)",
+    "color": "",
+    "colorKorean": "그레이",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 110,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/bd93c0f2447dd85da7d6debc9474c72b.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "openSize": "35x25x10cm"
+    },
+    "_productNo": "2685",
+    "_detailUrl": "https://www.kovea.co.kr/product/소프트-에어-필로우-035-그레이/2685/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECQ9WP-04GR000/KECQ9WP-04GR000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2683",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "컴포트 럭스 더블 (블루)",
+    "color": "",
+    "colorKorean": "블루",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/f30873ce9b41f678b1f40aa872dfe212.png",
+    "specs": {},
+    "_productNo": "2683",
+    "_detailUrl": "https://www.kovea.co.kr/product/컴포트-럭스-더블-블루/2683/",
+    "_specImages": [],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2682",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "컴포트 카매트 (베이지)",
+    "color": "",
+    "colorKorean": "베이지",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/343e071b98b7aa296193c2060075a228.png",
+    "specs": {},
+    "_productNo": "2682",
+    "_detailUrl": "https://www.kovea.co.kr/product/컴포트-카매트-베이지/2682/",
+    "_specImages": [],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2681",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "허니콤 자충매트 싱글 R-5 (샌드)",
+    "color": "",
+    "colorKorean": "샌드",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1900,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/0d619df5a2c641db4dc1f424b4f3eb12.jpg",
+    "specs": {
+      "material": "나일론",
+      "openSize": "21x70cm"
+    },
+    "_productNo": "2681",
+    "_detailUrl": "https://www.kovea.co.kr/product/허니콤-자충매트-싱글-r-5-샌드/2681/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KECQ9WU-01SD000/KECQ9WU-01SD000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2680",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "코지 극세사 전기매트 140 (그레이)",
+    "color": "",
+    "colorKorean": "그레이",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/d9702198a09bd9f48e1c7ee688ba81f5.png",
+    "specs": {},
+    "_productNo": "2680",
+    "_detailUrl": "https://www.kovea.co.kr/product/코지-극세사-전기매트-140-그레이/2680/",
+    "_specImages": [],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2679",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "코지 극세사 전기매트 240 (그레이)",
+    "color": "",
+    "colorKorean": "그레이",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/2e6d80bc3885e866e5d9d945e53e6e10.png",
+    "specs": {},
+    "_productNo": "2679",
+    "_detailUrl": "https://www.kovea.co.kr/product/코지-극세사-전기매트-240-그레이/2679/",
+    "_specImages": [],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2678",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "케이블 오토펌프",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/1efedc7425b7d7a539d2a7c8d7db789d.png",
+    "specs": {},
+    "_productNo": "2678",
+    "_detailUrl": "https://www.kovea.co.kr/product/케이블-오토펌프/2678/",
+    "_specImages": [],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2677",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "코튼 필로우 035 [그레이]",
+    "color": "",
+    "colorKorean": "그레이",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 330,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/73c5af20364e8582e6825ce39a3f83e2.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "openSize": "35x20x10cm"
+    },
+    "_productNo": "2677",
+    "_detailUrl": "https://www.kovea.co.kr/product/코튼-필로우-035-그레이/2677/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2024/KECQ9WP-05GR000/KECQ9WP-05GR000.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2676",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "코튼 필로우 035 [모스그린]",
+    "color": "",
+    "colorKorean": "모스그린",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 330,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/958975ceae95caaa56fc5fc3be676a69.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "openSize": "35x20x10cm"
+    },
+    "_productNo": "2676",
+    "_detailUrl": "https://www.kovea.co.kr/product/코튼-필로우-035-모스그린/2676/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2024/KECQ9WP-05MS000/KECQ9WP-05MS000.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2672",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "허니콤 자충매트 더블 캠핑 매트",
+    "color": "",
+    "colorKorean": "샌드",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 4200,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/0938a3c9aea6fee49b521df73d102e14.jpg",
+    "specs": {
+      "material": "나일론",
+      "openSize": "30x66cm"
+    },
+    "_productNo": "2672",
+    "_detailUrl": "https://www.kovea.co.kr/product/허니콤-자충매트-더블-캠핑-매트/2672/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19WU-01SD000/KEC19WU-01SD000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2671",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "디럭스패브릭매트 브라운",
+    "color": "",
+    "colorKorean": "브라운",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/d3dbd620a0115f03ffa1c153f52b878d.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "openSize": "160x200cm"
+    },
+    "_productNo": "2671",
+    "_detailUrl": "https://www.kovea.co.kr/product/디럭스패브릭매트-브라운/2671/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9WF-01BW000/KECP9WF-01BW000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_1242",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "에어 밸런스 매트 140",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/bce9fb1a85a6af39b6a63f6bee3f89b9.jpg",
+    "specs": {},
+    "_productNo": "1242",
+    "_detailUrl": "https://www.kovea.co.kr/product/에어-밸런스-매트-140/1242/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/kovea/421f1a1fa5a64b59d47d933143c880be.jpg",
+      "https://www.kovea.co.kr/web/upload/kovea/95fe8613ad337172faf83058269d9670.jpg",
+      "https://www.kovea.co.kr/web/upload/kovea/d6454078d061d9bfc774550114131501.jpg",
+      "https://www.kovea.co.kr/web/upload/kovea/5f203e6a505f82a47c0573f6ce916906.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2675",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "컴팩트 에어 필로우 045",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 92,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/96ae7af05e44c3ae4d0383d7b942a001.jpg",
+    "specs": {
+      "material": "폴리에스테르"
+    },
+    "_productNo": "2675",
+    "_detailUrl": "https://www.kovea.co.kr/product/컴팩트-에어-필로우-045/2675/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_01/KECQ9WP-06GK000/KECQ9WP-06GK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2670",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "디럭스패브릭매트 네이비",
+    "color": "",
+    "colorKorean": "네이비",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/81e0cf0d4f20e54c6dde225fe1bece4a.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "openSize": "160x200cm"
+    },
+    "_productNo": "2670",
+    "_detailUrl": "https://www.kovea.co.kr/product/디럭스패브릭매트-네이비/2670/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9WF-01NY000/KECP9WF-01NY000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2686",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "멀티 에어 필로우",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/1e13795a58890fd82de9cc50e0ed8e68.png",
+    "specs": {},
+    "_productNo": "2686",
+    "_detailUrl": "https://www.kovea.co.kr/product/멀티-에어-필로우/2686/",
+    "_specImages": [],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2684",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "에버닌 땅콩 베개 (브라운)",
+    "color": "",
+    "colorKorean": "브라운",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 80,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/43963665a28669c021b5c000810ab105.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "openSize": "38x20x12cm"
+    },
+    "_productNo": "2684",
+    "_detailUrl": "https://www.kovea.co.kr/product/에버닌-땅콩-베개-브라운/2684/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/KECQ9WP-01BW000/KECQ9WP-01BW000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2674",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "라이트 에어 매트 싱글 캠핑 매트 그레이카키",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 435,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/8b99713b4ec27254f60caad32242f480.jpg",
+    "specs": {
+      "material": "나일론"
+    },
+    "_productNo": "2674",
+    "_detailUrl": "https://www.kovea.co.kr/product/라이트-에어-매트-싱글-캠핑-매트-그레이카키/2674/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_04/KEC19WA-01GK000/KEC19WA-01GK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_2673",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "라이트 에어 매트 싱글 캠핑 매트 다크그레이",
+    "color": "",
+    "colorKorean": "다크그레이",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 435,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/76fa832dbec96591e33ef6b27c8000a3.jpg",
+    "specs": {
+      "material": "나일론"
+    },
+    "_productNo": "2673",
+    "_detailUrl": "https://www.kovea.co.kr/product/라이트-에어-매트-싱글-캠핑-매트-다크그레이/2673/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_04/KEC19WA-01GK000/KEC19WA-01GK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=644"
+  },
+  {
+    "groupId": "kovea_3217",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "호롱랜턴 (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 270,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202604/38cdb6c62ff134992a6fa8b081df4101.jpg",
+    "specs": {
+      "batteryType": "rechargeable"
+    },
+    "_productNo": "3217",
+    "_detailUrl": "https://www.kovea.co.kr/product/호롱랜턴-블랙/3217/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/NNEditor/20260427/copy-1777252179-DSFDSFDSSDF.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_3216",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "호롱랜턴 (아이보리)",
+    "color": "",
+    "colorKorean": "아이보리",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 270,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202604/32b8b61dfa906da6028954602545172d.jpg",
+    "specs": {
+      "batteryType": "rechargeable"
+    },
+    "_productNo": "3216",
+    "_detailUrl": "https://www.kovea.co.kr/product/호롱랜턴-아이보리/3216/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/NNEditor/20260427/copy-1777252113-DSFDSFDSSDF.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_3117",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "멀티 헤드 랜턴 300LM 캠핑 LED",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 80,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/2be3a7a1cdd582f4e130985c269f7bf8.jpg",
+    "specs": {
+      "maxBrightness": 300,
+      "batteryType": "rechargeable"
+    },
+    "_productNo": "3117",
+    "_detailUrl": "https://www.kovea.co.kr/product/멀티-헤드-랜턴-300lm-캠핑-led/3117/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29LH-03DS000/KEC29LH-03DS-01.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29LH-03DS000/KEC29LH-03DS-03.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29LH-03DS000/KEC29LH-03DS-05.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29LH-03DS000/KEC29LH-03DS-07.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29LH-03DS000/KEC29LH-03DS-09.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29LH-03DS000/KEC29LH-03DS-10.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_2957",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "마이크로 헤드랜턴",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/1f64b9e9417025c4983fc8db83e7afa6.png",
+    "specs": {},
+    "_productNo": "2957",
+    "_detailUrl": "https://www.kovea.co.kr/product/마이크로-헤드랜턴/2957/",
+    "_specImages": [],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_2883",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "리코 랜턴 (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/ee6fdd14c5ce0c47137565b5bcf9eaa2.png",
+    "specs": {
+      "batteryType": "rechargeable"
+    },
+    "_productNo": "2883",
+    "_detailUrl": "https://www.kovea.co.kr/product/리코-랜턴-블랙/2883/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9LD-02/KECP9LD-02_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_2882",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "리코 랜턴 (아이보리)",
+    "color": "",
+    "colorKorean": "아이보리",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/3120aabe28369197e679c85a106f6737.png",
+    "specs": {
+      "batteryType": "rechargeable"
+    },
+    "_productNo": "2882",
+    "_detailUrl": "https://www.kovea.co.kr/product/리코-랜턴-아이보리/2882/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9LD-02/KECP9LD-02_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_2881",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "리코 랜턴 (코코아)",
+    "color": "",
+    "colorKorean": "코코아",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/3a430890c7accb58814d7be13e3fb548.png",
+    "specs": {
+      "batteryType": "rechargeable"
+    },
+    "_productNo": "2881",
+    "_detailUrl": "https://www.kovea.co.kr/product/리코-랜턴-코코아/2881/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9LD-02/KECP9LD-02_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_2719",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "마키나 랜턴 (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 400,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202510/1fcdd3a3336b7e2bbd5ea24048f55aeb.png",
+    "specs": {
+      "maxBrightness": 8,
+      "batteryType": "rechargeable"
+    },
+    "_productNo": "2719",
+    "_detailUrl": "https://www.kovea.co.kr/product/마키나-랜턴-블랙/2719/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9LD-01BK000/KECP9LD-01BK000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_2718",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "마키나 랜턴 (화이트)",
+    "color": "",
+    "colorKorean": "화이트",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 400,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202510/422f9b93e1f3c75419a6d5a1f3169f4d.png",
+    "specs": {
+      "maxBrightness": 8,
+      "batteryType": "rechargeable"
+    },
+    "_productNo": "2718",
+    "_detailUrl": "https://www.kovea.co.kr/product/마키나-랜턴-화이트/2718/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECP9LD-01WH000/KECP9LD-01WH000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_2717",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "문라이트 LED 랜턴",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 170,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/deceb0f17550cebc3d7097a3f30bc351.png",
+    "specs": {
+      "batteryType": "rechargeable"
+    },
+    "_productNo": "2717",
+    "_detailUrl": "https://www.kovea.co.kr/product/문라이트-led-랜턴/2717/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9LD-03ZZ000/KECX9LD-03ZZ000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_2714",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "머큐리 Ⅱ",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 88,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/36bf8de8847d987a07e4b8666ca14359.png",
+    "specs": {
+      "maxBrightness": 200,
+      "batteryType": "rechargeable",
+      "maxRuntime": 7
+    },
+    "_productNo": "2714",
+    "_detailUrl": "https://www.kovea.co.kr/product/머큐리/2714/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECU9LH-01ZZ000/KECU9LH-01ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECU9LH-01ZZ000/KECU9LH-01ZZ000_02.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_2710",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "에버닌 릴리 랜턴",
+    "color": "",
+    "colorKorean": "베이지",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 300,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/6e0f754e39bb4a3f19a5251d2f7f0df6.jpg",
+    "specs": {
+      "maxBrightness": 250,
+      "batteryType": "rechargeable"
+    },
+    "_productNo": "2710",
+    "_detailUrl": "https://www.kovea.co.kr/product/에버닌-릴리-랜턴/2710/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECQ9LD-01BE000/KECQ9LD-01BE000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECQ9LD-01BE000/KECQ9LD-01BE000_03.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECQ9LD-01BE000/KECQ9LD-01BE000_05.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_1194",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "토러스 M",
+    "color": "",
+    "colorKorean": "카키",
+    "size": "M",
+    "sizeKorean": "미디엄",
+    "weight": 404,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/87bc79a6609395535b8cd497d1a1331c.jpg",
+    "specs": {
+      "batteryType": "rechargeable"
+    },
+    "_productNo": "1194",
+    "_detailUrl": "https://www.kovea.co.kr/product/토러스-m/1194/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECT9LL-03KH000/KECT9LL-03KH000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECT9LL-03KH000/KECT9LL-03KH000_02.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECT9LL-03KH000/KECT9LL-03KH000_03.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECT9LL-03KH000/KECT9LL-03KH000_04.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_1038",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "레트로 랜턴",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/4b8a06f6d6a520480985aa1daa5d1ace.jpg",
+    "specs": {},
+    "_productNo": "1038",
+    "_detailUrl": "https://www.kovea.co.kr/product/레트로-랜턴/1038/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECS9LL-01ZZ000/KECS9LL-01ZZ000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_253",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "스파이더 LED 헤드랜턴",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/1e279916cba36f3f3f3d28a743bad228.jpg",
+    "specs": {},
+    "_productNo": "253",
+    "_detailUrl": "https://www.kovea.co.kr/product/스파이더-led-헤드랜턴/253/",
+    "_specImages": [],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_2716",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "아모르 Ⅱ M (다크그레이)",
+    "color": "",
+    "colorKorean": "다크그레이",
+    "size": "M",
+    "sizeKorean": "미디엄",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/77f83fd7129477745babaed7d949de8c.jpg",
+    "specs": {},
+    "_productNo": "2716",
+    "_detailUrl": "https://www.kovea.co.kr/product/아모르-m-다크그레이/2716/",
+    "_specImages": [],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_2715",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "아모르 Ⅱ M (옐로우)",
+    "color": "",
+    "colorKorean": "옐로우",
+    "size": "M",
+    "sizeKorean": "미디엄",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/dfb8139e75e8f7d2840379c7816e1b84.jpg",
+    "specs": {},
+    "_productNo": "2715",
+    "_detailUrl": "https://www.kovea.co.kr/product/아모르-m-옐로우/2715/",
+    "_specImages": [],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_2712",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "문빔",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 112,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/1e6fb28a85ff813c591cd2fe0b66fdc4.png",
+    "specs": {
+      "maxBrightness": 580,
+      "batteryType": "rechargeable",
+      "maxRuntime": 2.5
+    },
+    "_productNo": "2712",
+    "_detailUrl": "https://www.kovea.co.kr/product/문빔/2712/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECV9LH-01ZZ000/KECV9LH-01ZZ000_01.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_2709",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "스피커 랜턴 [카키]",
+    "color": "",
+    "colorKorean": "카키",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/b23a530e3d5c00c72a60019ebf753bee.jpg",
+    "specs": {},
+    "_productNo": "2709",
+    "_detailUrl": "https://www.kovea.co.kr/product/스피커-랜턴-카키/2709/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2024/KECQ9LD-02KH000/KECQ9LD-02KH000.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_3118",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "센서 헤드 랜턴 650LM 플러스 캠핑 LED",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 57,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202605/d863bf44efb541ab44171a4e3b6a2272.jpg",
+    "specs": {
+      "maxBrightness": 650,
+      "batteryType": "rechargeable"
+    },
+    "_productNo": "3118",
+    "_detailUrl": "https://www.kovea.co.kr/product/센서-헤드-랜턴-650lm-플러스-캠핑-led/3118/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29LH-01DS000/KEC29LH-01DS-01.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29LH-01DS000/KEC29LH-01DS-03.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29LH-01DS000/KEC29LH-01DS-05.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29LH-01DS000/KEC29LH-01DS-07.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29LH-01DS000/KEC29LH-01DS-09.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_2884",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "센서 헤드랜턴 650LM LED 충전식 헤드램프 (딥샌드)",
+    "color": "",
+    "colorKorean": "딥샌드",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 57,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/caafca995d6defe4618a2a8e4f13c2eb.jpg",
+    "specs": {
+      "maxBrightness": 650,
+      "batteryType": "rechargeable"
+    },
+    "_productNo": "2884",
+    "_detailUrl": "https://www.kovea.co.kr/product/센서-헤드랜턴-650lm-led-충전식-헤드램프/2884/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19LH-01/KECQ9LH-01_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19LH-01/KECQ9LH-01_03.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19LH-01/KECQ9LH-01_05.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19LH-01/KECQ9LH-01_07.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19LH-01/KECQ9LH-01_09.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_2884",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "센서 헤드랜턴 650LM LED 충전식 헤드램프 (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 57,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/caafca995d6defe4618a2a8e4f13c2eb.jpg",
+    "specs": {
+      "maxBrightness": 650,
+      "batteryType": "rechargeable"
+    },
+    "_productNo": "2884",
+    "_detailUrl": "https://www.kovea.co.kr/product/센서-헤드랜턴-650lm-led-충전식-헤드램프/2884/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19LH-01/KECQ9LH-01_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19LH-01/KECQ9LH-01_03.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19LH-01/KECQ9LH-01_05.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19LH-01/KECQ9LH-01_07.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19LH-01/KECQ9LH-01_09.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_2884",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "센서 헤드랜턴 650LM LED 충전식 헤드램프 (카키)",
+    "color": "",
+    "colorKorean": "카키",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 57,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/caafca995d6defe4618a2a8e4f13c2eb.jpg",
+    "specs": {
+      "maxBrightness": 650,
+      "batteryType": "rechargeable"
+    },
+    "_productNo": "2884",
+    "_detailUrl": "https://www.kovea.co.kr/product/센서-헤드랜턴-650lm-led-충전식-헤드램프/2884/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19LH-01/KECQ9LH-01_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19LH-01/KECQ9LH-01_03.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19LH-01/KECQ9LH-01_05.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19LH-01/KECQ9LH-01_07.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19LH-01/KECQ9LH-01_09.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_77",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "메그니파이어Ⅱ",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/a10704583b913cd7e633afcc3d3b939c.jpg",
+    "specs": {},
+    "_productNo": "77",
+    "_detailUrl": "https://www.kovea.co.kr/product/메그니파이어/77/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECZ9LF-10ZZ000/KECZ9LF-10ZZ000_02.jpg",
+      "https://www.kovea.co.kr/web/upload/kovea/829f9303f77e8ef53c055bb0e57f23ce.jpg"
+    ],
+    "_source": "https://www.kovea.co.kr/product/list.html?cate_no=670"
+  },
+  {
+    "groupId": "kovea_118",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "[아울렛] 캐슬이너그라운드시트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/ca027d3934070859c9a071b4030f8a84.jpg",
+    "specs": {},
+    "_productNo": "118",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/118/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/outlet.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECH9AG-01ZZFRE/KECH9AG-01ZZFRE_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_156",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "알파인1솔로이스트그라운드시트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 154,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/b96658df86efab8f9017d7d9dbb17e7e.jpg",
+    "specs": {
+      "size": "71x235cm"
+    },
+    "_productNo": "156",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/156/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/outlet.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECJ9AG-02ZZ000/KECJ9AG-02ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_158",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "캐슬리빙그라운드시트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 900,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/6f258347b756035e563b015df3a2395c.jpg",
+    "specs": {
+      "size": "380x375cm"
+    },
+    "_productNo": "158",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/158/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/outlet.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECJ9AG-10ZZ000/KECJ9AG-10ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_227",
+    "category": "pouch",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "2단 테이블 캐리백",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/f2e6516a9e516de78b0fb34e6d239f38.jpg",
+    "specs": {},
+    "_productNo": "227",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/227/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/outlet.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECJ9BT-07ZZ000/KECJ9BT-07ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_240",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "[아울렛] 그레이트파빌리온동계루프",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/e68b881ff92d9f4a169c7994cefc7c82.jpg",
+    "specs": {},
+    "_productNo": "240",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/240/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/outlet.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECJ9AR-01ZZ000/KECJ9AR-01ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_252",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "마이크로 헤드랜턴2",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/0c1017517d53bc8b8ac6f95259bbabfd.jpg",
+    "specs": {},
+    "_productNo": "252",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/252/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_271",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "아웃백이너그라운드시트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/45a21ebc20ed66f2c06f6924d0139e49.jpg",
+    "specs": {},
+    "_productNo": "271",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/271/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_500",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "알파인UL1000그라운드시트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/5cd8fbbbc8954001d1bdf80f07ec1fab.jpg",
+    "specs": {},
+    "_productNo": "500",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/500/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/outlet.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECL9AG-05ZZ000/KECL9AG-05ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_540",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "아웃백솔리드이너그라운드시트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 600,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/a19cd1bddd663baca23415435c24fb1e.jpg",
+    "specs": {
+      "size": "250x195cm"
+    },
+    "_productNo": "540",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/540/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/outlet.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECM9AG-05ZZ000/KECM9AG-05ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_544",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "아웃백옴니이너그라운드시트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 660,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/aee502db4848885a38863ec33c04bf49.jpg",
+    "specs": {
+      "size": "270x180cm"
+    },
+    "_productNo": "544",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/544/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/outlet.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECM9AG-04ZZ000/KECM9AG-04ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_607",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "3&amp;4폴딩 테이블 렉",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 200,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/8af658ed7e6d09bdd6162a10a71bf3d1.jpg",
+    "specs": {},
+    "_productNo": "607",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/607/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECM9FZ-01ZZ000/KECM9FZ-01ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_664",
+    "category": "pouch",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "2웨이 키친 테이블 캐리백Ⅱ(M)",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/d06f3ba7b349ca61a2fc581f1e1f799f.jpg",
+    "specs": {},
+    "_productNo": "664",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/664/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECM9BT-02ZZ000/KECM9BT-02ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_688",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "스타게이트블랙이너그라운드시트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 820,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/add19be8df2c3bf53d34ef14175dd081.jpg",
+    "specs": {},
+    "_productNo": "688",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/688/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/outlet.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECN9AG-07ZZ000/KECN9AG-07ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_857",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "휴메이트그라운드시트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 620,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/e8e5280ae638181594c9cce4c164e733.jpg",
+    "specs": {
+      "material": "폴리에스테르"
+    },
+    "_productNo": "857",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/857/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/outlet.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECR9AG-03ZZ000/KECR9AG-03ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_1282",
+    "category": "pouch",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "밤부 원액션 라운드 테이블(S) 캐리백",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/93a02d859c567ba43c199f5b5992d757.jpg",
+    "specs": {},
+    "_productNo": "1282",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/1282/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/outlet.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECS9BT-03ZZ000/KECS9BT-03ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_1349",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "라이트 테이블 S(메쉬)",
+    "color": "",
+    "colorKorean": "",
+    "size": "S",
+    "sizeKorean": "스몰",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/f06f3319e27d133560759020290e85a0.jpg",
+    "specs": {},
+    "_productNo": "1349",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/1349/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/kovea/9d8a8c92c4612b860a8b5285b3ab8afc.jpg",
+      "https://www.kovea.co.kr/web/upload/kovea/67b5074d66c608850a783b0f5cf51319.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_1560",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "테이블보V(L)",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/dfea596136b4cbd5bd87ccf745db68bc.jpg",
+    "specs": {},
+    "_productNo": "1560",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/1560/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_1592",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "스파이더 LED 헤드랜턴 [P]",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/8d9f8fbb42dcdfa240b28ac1271de03c.jpg",
+    "specs": {},
+    "_productNo": "1592",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/1592/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/kovea/e1be588150f71005030955112fb73690.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_1648",
+    "category": "tarp",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "비틀쉐이드 II",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 4400,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/a6ce8529a01e8e0227a68df17253af6d.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "fiberglass"
+    },
+    "_productNo": "1648",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/1648/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/outlet.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECW9TS-06YE000/KECW9TS-06YE000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECW9TS-06YE000/KECW9TS-06YE000_02.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_1827",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "나일론 루프 슬링 120",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/f2c0e848858f9a36aa234f2dfb02c6f3.jpg",
+    "specs": {},
+    "_productNo": "1827",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/1827/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/NNEditor/20260427/TS-NL15-12020Nylon20Loop20Sling_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_1828",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "나일론 루프 슬링 30",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/132a403560ff3e2924c3b5a9aa50670d.jpg",
+    "specs": {},
+    "_productNo": "1828",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/1828/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/NNEditor/20260427/TS-NL15-3020Nylon20Loop20Sling_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_1829",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "나일론 루프 슬링 60",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/dc1476a322b4f3577397352494046d91.jpg",
+    "specs": {},
+    "_productNo": "1829",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/1829/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/NNEditor/20260427/TS-NL15-6020Nylon20Loop20Sling_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_1830",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "나일론 루프 슬링 90",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/cf0f495323f08da70309d26a89b10a76.jpg",
+    "specs": {},
+    "_productNo": "1830",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/1830/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/NNEditor/20260427/TS-NL15-9020Nylon20Loop20Sling_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_1833",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "다이니마 루프 슬링 120",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/48a413d7e83861ceee1dc9a31e83d5de.jpg",
+    "specs": {},
+    "_productNo": "1833",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/1833/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/NNEditor/20260427/TS-DL12-12020Dynemma20Loop20Sling_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_1834",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "다이니마 루프 슬링 30",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/237a9ed728b140b991c88834575bef2b.jpg",
+    "specs": {},
+    "_productNo": "1834",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/1834/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/NNEditor/20260427/TS-DL12-3020Dynemma20Loop20Sling_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_1835",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "다이니마 루프 슬링 60",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/d4bc0618712bd3415304f20fbc05fc9b.jpg",
+    "specs": {},
+    "_productNo": "1835",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/1835/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/NNEditor/20260427/TS-DL12-6020Dynemma20Loop20Sling_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_1836",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "다이니마 루프 슬링 90",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/218da511f2875a584accb401b2c3683b.jpg",
+    "specs": {},
+    "_productNo": "1836",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/1836/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/NNEditor/20260427/TS-DL12-9020Dynemma20Loop20Sling_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_1921",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "레아Ⅱ 헤드랜턴",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/38225484b4f7c1dd488c4f3f8128e960.jpg",
+    "specs": {},
+    "_productNo": "1921",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/1921/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/NNEditor/20260428/THL-17920Rhea2_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_1924",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "아톤 헤드랜턴",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/64775ceb005a6daaec6a9164d088dddd.jpg",
+    "specs": {},
+    "_productNo": "1924",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/1924/",
+    "_specImages": [
+      "https://www.kovea.co.kr/web/upload/NNEditor/20260428/THL-18420Aton_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2302",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "NH YL11 경량 락킹체어 (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/da622f55fb69d5aa387f6674677b4e1c.jpg",
+    "specs": {},
+    "_productNo": "2302",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2302/",
+    "_specImages": [],
+    "_source": "sitemap"
+  },
+  {
+    "groupId": "kovea_2302",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "NH YL11 경량 락킹체어 (베이지)",
+    "color": "",
+    "colorKorean": "베이지",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/da622f55fb69d5aa387f6674677b4e1c.jpg",
+    "specs": {},
+    "_productNo": "2302",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2302/",
+    "_specImages": [],
+    "_source": "sitemap"
+  },
+  {
+    "groupId": "kovea_2302",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "NH YL11 경량 락킹체어 (카키)",
+    "color": "",
+    "colorKorean": "카키",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/da622f55fb69d5aa387f6674677b4e1c.jpg",
+    "specs": {},
+    "_productNo": "2302",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2302/",
+    "_specImages": [],
+    "_source": "sitemap"
+  },
+  {
+    "groupId": "kovea_2338",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "NH IGT 시스템테이블 모듈",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/8fcef91cd23cf8457959fb2d6ea78dfc.jpg",
+    "specs": {},
+    "_productNo": "2338",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2338/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2353",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "PetPlay 캠핑장비 콜렉션 (랜턴)",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 118,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/e01b720a8ebf0b8878bdfa8ad9e5f1e8.jpg",
+    "specs": {
+      "batteryType": "rechargeable"
+    },
+    "_productNo": "2353",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2353/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/4EPP9KY-03MXONE/4EPP9KY-03MXONE_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2357",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "PetPlay 캠핑장비 콜렉션 (텐트)",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 100,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/d9036c68385ff13a9d36d3f29d0eb4b4.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르"
+    },
+    "_productNo": "2357",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2357/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/4EPP9KY-02MXONE/4EPP9KY-02MXONE_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2371",
+    "category": "pouch",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "PetPlay 아웃도어 컴팩트 트레이닝 파우치 S (바닐라)",
+    "color": "",
+    "colorKorean": "바닐라",
+    "size": "S",
+    "sizeKorean": "스몰",
+    "weight": 41,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/1785a21121e3e0b520ec96667df448b3.jpg",
+    "specs": {},
+    "_productNo": "2371",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2371/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/4EPP9KZ-02VN00S/4EPP9KZ-02VN00S_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2372",
+    "category": "pouch",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "PetPlay 아웃도어 디럭스 트레이닝 파우치 S (바닐라)",
+    "color": "",
+    "colorKorean": "바닐라",
+    "size": "S",
+    "sizeKorean": "스몰",
+    "weight": 100,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/e91254f2a8248aa767881708515642d4.jpg",
+    "specs": {},
+    "_productNo": "2372",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2372/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/4EPP9KZ-03VN00S/4EPP9KZ-03VN00S_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2376",
+    "category": "pouch",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "PetPlay 디럭스 트레이닝 파우치 (PetPlay 아웃도어 보울 (리버))",
+    "color": "",
+    "colorKorean": "PetPlay 아웃도어 보울 (리버)",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 100,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/5604b5b35c906ac19b6ee0046db81606.jpg",
+    "specs": {},
+    "_productNo": "2376",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2376/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/4EPP9KZ-05/4EPP9KZ-05_01.jpg"
+    ],
+    "_source": "sitemap"
+  },
+  {
+    "groupId": "kovea_2376",
+    "category": "pouch",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "PetPlay 디럭스 트레이닝 파우치 (PetPlay 아웃도어 보울 (모스))",
+    "color": "",
+    "colorKorean": "PetPlay 아웃도어 보울 (모스)",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 100,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/5604b5b35c906ac19b6ee0046db81606.jpg",
+    "specs": {},
+    "_productNo": "2376",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2376/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/4EPP9KZ-05/4EPP9KZ-05_01.jpg"
+    ],
+    "_source": "sitemap"
+  },
+  {
+    "groupId": "kovea_2411",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "라운드 사이드 테이블 S [블랙]",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/5bc426960f001f2407cf37fa2d670dbb.jpg",
+    "specs": {},
+    "_productNo": "2411",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2411/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2415",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "NH YL15 높이조절 문 체어 (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/982ec88c86c8cc80bf1fe36871257968.jpg",
+    "specs": {},
+    "_productNo": "2415",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2415/",
+    "_specImages": [],
+    "_source": "sitemap"
+  },
+  {
+    "groupId": "kovea_2415",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "NH YL15 높이조절 문 체어 (크림)",
+    "color": "",
+    "colorKorean": "크림",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/982ec88c86c8cc80bf1fe36871257968.jpg",
+    "specs": {},
+    "_productNo": "2415",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2415/",
+    "_specImages": [],
+    "_source": "sitemap"
+  },
+  {
+    "groupId": "kovea_2442",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "에어 스툴 소파 [베이지]",
+    "color": "",
+    "colorKorean": "베이지",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/5a0dea8310e73084f096dc9628d636f7.jpg",
+    "specs": {},
+    "_productNo": "2442",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2442/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2462",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "초경량 스퀘어 에어매트 3.5 싱글 L [그레이]",
+    "color": "",
+    "colorKorean": "그레이",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/44994cf1f44bd45038c5ac0499e4c91f.jpg",
+    "specs": {},
+    "_productNo": "2462",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2462/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2463",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "초경량 스퀘어 에어매트 5.8 싱글 M [실버]",
+    "color": "",
+    "colorKorean": "실버",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/57bbfff0c5a6ed694c0c4fab840bebcc.jpg",
+    "specs": {},
+    "_productNo": "2463",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2463/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2466",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "더블 에어매트 15CM [베이지]",
+    "color": "",
+    "colorKorean": "베이지",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/4d4a1ce3848eb4de41d73e3a1fceddf7.jpg",
+    "specs": {},
+    "_productNo": "2466",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2466/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2471",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "NH HD 14단매트 플러스 (블루)",
+    "color": "",
+    "colorKorean": "블루",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/0c0711a27a77fb4d5c1014c59c4f6c08.jpg",
+    "specs": {},
+    "_productNo": "2471",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2471/",
+    "_specImages": [],
+    "_source": "sitemap"
+  },
+  {
+    "groupId": "kovea_2471",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "NH HD 14단매트 플러스 (옐로우)",
+    "color": "",
+    "colorKorean": "옐로우",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/0c0711a27a77fb4d5c1014c59c4f6c08.jpg",
+    "specs": {},
+    "_productNo": "2471",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2471/",
+    "_specImages": [],
+    "_source": "sitemap"
+  },
+  {
+    "groupId": "kovea_2472",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "코튼 싱글 매트커버 [베이지]",
+    "color": "",
+    "colorKorean": "베이지",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/4327351de66c822d28057e48167ee31b.jpg",
+    "specs": {},
+    "_productNo": "2472",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2472/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2492",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "듄 10.9 캐노피 텐트 [옐로우]",
+    "color": "",
+    "colorKorean": "옐로우",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/a2afc7d3a1bf1133cf8d37170ba3db9b.jpg",
+    "specs": {},
+    "_productNo": "2492",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2492/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2494",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "빌리지 13 거실형 텐트 [베이지] (이너텐트 미포함)",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/7f747cca1b5fb55761627473b9cd0003.jpg",
+    "specs": {},
+    "_productNo": "2494",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2494/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2496",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "빌리지 17 오토 텐트 [다크브라운]",
+    "color": "",
+    "colorKorean": "다크브라운",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/72b5731c9a07e6490a0c3ea454638f6e.jpg",
+    "specs": {},
+    "_productNo": "2496",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2496/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2499",
+    "category": "tarp",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "스카이 옥타곤 타프 L [베이지]",
+    "color": "",
+    "colorKorean": "베이지",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/092e8ff6a7d196eec2afa3e6b0e3350f.jpg",
+    "specs": {},
+    "_productNo": "2499",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2499/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2506",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "두랄루민 롤 테이블 [브라운]",
+    "color": "",
+    "colorKorean": "브라운",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/7e5fe30ec7a2e56fbfd6238c03379c53.jpg",
+    "specs": {},
+    "_productNo": "2506",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2506/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2512",
+    "category": "sleeping_bag",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "후드 더블 침낭 [브라운]",
+    "color": "",
+    "colorKorean": "브라운",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/50c8cc9e25bdf5e7e9badf27fa67d3ae.jpg",
+    "specs": {},
+    "_productNo": "2512",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2512/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2515",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "울트라라이트 경량코트 [카키베이지]",
+    "color": "",
+    "colorKorean": "카키베이지",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/42e885f20871ff39446ce119a9130893.jpg",
+    "specs": {},
+    "_productNo": "2515",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2515/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2520",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "네이쳐하이크 빅 더블 자충매트10 [베이지]",
+    "color": "",
+    "colorKorean": "베이지",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/f15c0e596ced174800e981fae6c47a21.jpg",
+    "specs": {},
+    "_productNo": "2520",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2520/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2533",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "NH IGT 시스템테이블 모듈(A세트)",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/430a4f3aa8225fe2b4510448be5b08b1.jpg",
+    "specs": {},
+    "_productNo": "2533",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2533/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2551",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "파이어플라이 (포레스트그린)",
+    "color": "",
+    "colorKorean": "포레스트그린",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 146,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/be026c307138738f0ef0d509c915e0e5.png",
+    "specs": {},
+    "_productNo": "2551",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2551/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9GL-04GN000/KECO9GL-04GN000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2552",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "파이어플라이 (루나아이보리)",
+    "color": "",
+    "colorKorean": "루나아이보리",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 146,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/19967e00c6db3bcbf4d41d08ff7a901d.png",
+    "specs": {},
+    "_productNo": "2552",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2552/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9GL-02IV000/KECO9GL-02IV000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2553",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "파이어플라이 (핑크블라썸)",
+    "color": "",
+    "colorKorean": "핑크블라썸",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 146,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/c109d62c99228a8496326116f5c8b088.png",
+    "specs": {},
+    "_productNo": "2553",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2553/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9GL-01PK000/KECO9GL-01PK000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2554",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "프리미엄 티탄 가스랜턴",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 100,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/3633cc7715165f62b2000b07978092cd.png",
+    "specs": {
+      "batteryType": "gas"
+    },
+    "_productNo": "2554",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2554/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECJ9GL-01ZZ000/KECJ9GL-01ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECJ9GL-01ZZ000/KECJ9GL-01ZZ000_02.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECJ9GL-01ZZ000/KECJ9GL-01ZZ000_03.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECJ9GL-01ZZ000/KECJ9GL-01ZZ000_04.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2597",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "슬림 트윈 스토브 (라이트)",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 4900,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/055cd6fa54112817856d93860eff7266.png",
+    "specs": {
+      "batteryType": "gas"
+    },
+    "_productNo": "2597",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2597/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECT9GS-04ZZ000/KECT9GS-04ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2626",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "테이블보VI S",
+    "color": "",
+    "colorKorean": "",
+    "size": "S",
+    "sizeKorean": "스몰",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/1593230f7df1513f5347978b0442314c.png",
+    "specs": {},
+    "_productNo": "2626",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2626/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9JH-03ZZ000/KECY9JH-03ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2627",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "테이블보VI M",
+    "color": "",
+    "colorKorean": "",
+    "size": "M",
+    "sizeKorean": "미디엄",
+    "weight": 253,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/3b0f119efd40c8a2fdd2028dc8044da0.png",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "110x165cm"
+    },
+    "_productNo": "2627",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2627/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9JH-02ZZ000/KECY9JH-02ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9JH-02ZZ000/KECY9JH-02ZZ000_02.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2628",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "테이블보VI L",
+    "color": "",
+    "colorKorean": "",
+    "size": "L",
+    "sizeKorean": "라지",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/86ec741f706ba9ba54a1184e9a628a56.png",
+    "specs": {},
+    "_productNo": "2628",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2628/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECY9JH-01ZZ000/KECY9JH-01ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2629",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "썸머가든 테이블보 S (아이보리)",
+    "color": "",
+    "colorKorean": "아이보리",
+    "size": "S",
+    "sizeKorean": "스몰",
+    "weight": 205,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/10f6365b2dab418388ddd2c4bd51b291.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "120x120cm"
+    },
+    "_productNo": "2629",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2629/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9JH-04IV000/KECO9JH-04IV000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2630",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "썸머가든 테이블보 M (아이보리)",
+    "color": "",
+    "colorKorean": "아이보리",
+    "size": "M",
+    "sizeKorean": "미디엄",
+    "weight": 253,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/60a67f60c96e8e8e5f052d2d1ca59e5a.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "110x165cm"
+    },
+    "_productNo": "2630",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2630/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9JH-03IV000/KECO9JH-03IV000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2631",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "썸머가든 테이블보 L (아이보리)",
+    "color": "",
+    "colorKorean": "아이보리",
+    "size": "L",
+    "sizeKorean": "라지",
+    "weight": 342,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/5b2d0086b9682e321837a5dce593277b.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "120x210cm"
+    },
+    "_productNo": "2631",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2631/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9JH-02IV000/KECO9JH-02IV000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2752",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "컨테이너 하드 케이스 캠핑 장비 케이스",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2800,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/c0a368bf681e1ab881db95e27efbd801.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르"
+    },
+    "_productNo": "2752",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2752/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19BM-04BK000/KEC19BM-04BK000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2754",
+    "category": "pouch",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "기가썬 히터 캐리백Ⅱ 챠콜",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 760,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/0ee03fd21d0355240e4e13d18731bc43.jpg",
+    "specs": {},
+    "_productNo": "2754",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2754/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECR7BH-01CH000/KECR7BH-01CH000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2758",
+    "category": "pouch",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "툴백 13.5L 캠핑 수납 가방",
+    "color": "",
+    "colorKorean": "카키",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1200,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/8f72c25a216e6f20a07b5e80c83a9b18.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "size": "47x27x15cm"
+    },
+    "_productNo": "2758",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2758/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_04/KEC19BM-03KH000/KEC19BM-03KH000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2760",
+    "category": "pouch",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "폴 캐리백 90 텐트 폴 가방",
+    "color": "",
+    "colorKorean": "카키",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/b033f8eec59e2c43f75b126ba5c7b72c.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "size": "90x16x14cm"
+    },
+    "_productNo": "2760",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2760/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_04/KEC19BP-01KH000/KEC19BP-01KH000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2764",
+    "category": "pouch",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "파워센스 캐리백 8L",
+    "color": "",
+    "colorKorean": "그레이",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 250,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/0e45c61f065bcb2f137c1db3e5c12f48.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "size": "22x30x26cm"
+    },
+    "_productNo": "2764",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2764/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_01/KECX7GH-01BK000/KECX7GH-01BK000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2766",
+    "category": "pouch",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "가스 캐리백 10L [그레이]",
+    "color": "",
+    "colorKorean": "그레이",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 430,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/2a1dda9e26923a7800457278b46ff094.jpg",
+    "specs": {
+      "material": "폴리에스테르",
+      "size": "20x23cm"
+    },
+    "_productNo": "2766",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2766/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2024/KECQ9BM-01GR000/KECQ9BM-01GR000.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2772",
+    "category": "pouch",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "미니렌지 캐리백 (차콜)",
+    "color": "",
+    "colorKorean": "차콜",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 420,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/5c02171878d4182024a42c831b02e51f.png",
+    "specs": {
+      "material": "폴리에스테르",
+      "size": "29x23x12cm"
+    },
+    "_productNo": "2772",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2772/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECS9BS-01CH000/KECS9BS-01CH000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2789",
+    "category": "tarp",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "와우 쉐이드 M",
+    "color": "",
+    "colorKorean": "",
+    "size": "M",
+    "sizeKorean": "미디엄",
+    "weight": 2600,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/32fbac070dfd665e7c8f0cae4bddac7e.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르",
+      "poleMaterial": "fiberglass",
+      "waterproofRating": 1200
+    },
+    "_productNo": "2789",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2789/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9TI-01ZZ000/KECX9TI-01ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2794",
+    "category": "tarp",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "고스트 헥사타프",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 4400,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/c8805fe0a6427db44f65286abf0d203e.jpg",
+    "specs": {
+      "flyMaterial": "나일론",
+      "poleMaterial": "aluminum",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2794",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2794/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9TT-02ZZ000/KECO9TT-02ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9TT-02ZZ000/KECO9TT-02ZZ000_02.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2795",
+    "category": "tarp",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "고스트 스퀘어타프",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 4500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/49a3b38c11183ddcb5a8d847674ca8b4.png",
+    "specs": {
+      "flyMaterial": "나일론",
+      "poleMaterial": "aluminum",
+      "waterproofRating": 2000
+    },
+    "_productNo": "2795",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2795/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9TT-03ZZ000/KECO9TT-03ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECO9TT-03ZZ000/KECO9TT-03ZZ000_02.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2885",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "트라이 앵글 스토퍼 II (8pcs)",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 10,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/a5b142088b8c8b535e6fdec612016772.png",
+    "specs": {},
+    "_productNo": "2885",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2885/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9AC-04ZZ000/KECX9AC-04ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECX9AC-04ZZ000/KECX9AC-04ZZ000_02.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2908",
+    "category": "tarp",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "타프하우스라이너",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/816564ab55eaa987187a8e4ca7c648a1.jpg",
+    "specs": {},
+    "_productNo": "2908",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2908/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECN9AF-02ZZ000/KECN9AF-02ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2909",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "코딘스퀘어티피이너스크린",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1140,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/af52862eb5e549285fc177aa0a5c12e0.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르"
+    },
+    "_productNo": "2909",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2909/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECS9AI-01ZZ000/KECS9AI-01ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2910",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "이스턴이너그라운드시트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/85d559389b2ba9027c7b2aa398914603.jpg",
+    "specs": {},
+    "_productNo": "2910",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2910/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECK9AG-02ZZ000/KECK9AG-02ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2911",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "아웃백 옴니 이너 카페트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/5a1fddedfe462b844269298fb205e3e9.jpg",
+    "specs": {},
+    "_productNo": "2911",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2911/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECM9WC-02ZZ000/KECM9WC-02ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2912",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "오페라블랙루프",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1600,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/2881fe25bf969775dc593160ff29fd0d.jpg",
+    "specs": {},
+    "_productNo": "2912",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2912/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECN9AR-06ZZ000/KECN9AR-06ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2913",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "오페라블랙이너그라운드시트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 900,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/3f1aeb3c26d3882c6f383addb23cce5b.jpg",
+    "specs": {
+      "material": "폴리에스테르"
+    },
+    "_productNo": "2913",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2913/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECN9AG-08ZZ000/KECN9AG-08ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECN9AG-08ZZ000/KECN9AG-08ZZ000_02.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2915",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "에버캠프블랙이너그라운드시트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 960,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/2a2e9f14e278ccab174c818b8e6ae936.jpg",
+    "specs": {},
+    "_productNo": "2915",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2915/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECN9AG-04ZZ000/KECN9AG-04ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2917",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "에버랜드리빙그라운드시트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1680,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/b3b6804f675c0abfaa642a49f4cc09e9.jpg",
+    "specs": {
+      "size": "350x303x315cm"
+    },
+    "_productNo": "2917",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2917/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECM9AG-02ZZ000/KECM9AG-02ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2918",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "비비드라이트코트스킨",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/6701a9e5edb06907724d775f472037b8.jpg",
+    "specs": {},
+    "_productNo": "2918",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2918/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECU9CC-01OR000/KECU9CC-01OR000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2919",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "아웃백솔리드루프",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 880,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/8e64b1eaff0c532542530ff2fab3f263.jpg",
+    "specs": {
+      "size": "265x205cm"
+    },
+    "_productNo": "2919",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2919/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECM9AR-02ZZ000/KECM9AR-02ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2920",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "아웃백블랙이너그라운드시트",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 800,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/f33153c88584bc3e9a495acf8e97f3ab.jpg",
+    "specs": {},
+    "_productNo": "2920",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2920/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECN9AG-02ZZ000/KECN9AG-02ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2926",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "페가수스 루프백 논슬립 패드Ⅱ",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 300,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/1b03b1322811e339334a5b288f1ca473.jpg",
+    "specs": {
+      "size": "110x70cm"
+    },
+    "_productNo": "2926",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2926/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/outlet.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECT9BR-01ZZ000/KECT9BR-01ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECT9BR-01ZZ000/KECT9BR-01ZZ000_02.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2927",
+    "category": "pouch",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "롤테이블 벤치 세트 캐리백",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 430,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/136b76e9818dbb015db2bf7ac0c7c8b5.jpg",
+    "specs": {},
+    "_productNo": "2927",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2927/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECK9BT-04ZZ000/KECK9BT-04ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2928",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "트라이 썬더 랜턴",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 950,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/0226ffd1a9381b8f585ca3e19dab36dd.jpg",
+    "specs": {
+      "batteryType": "rechargeable"
+    },
+    "_productNo": "2928",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2928/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/CECN9LL-01YE000/CECN9LL-01YE000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2929",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "2웨이 LED 랜턴",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 88,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/bf44b0da8c1e270348e7b2d5acda574b.jpg",
+    "specs": {
+      "maxBrightness": 176,
+      "batteryType": "rechargeable"
+    },
+    "_productNo": "2929",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2929/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/CECT9LL-01LM000/CECT9LL-01LM000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/CECT9LL-01LM000/CECT9LL-01LM000_02.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/CECT9LL-01LM000/CECT9LL-01LM000_03.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2932",
+    "category": "tent_acc",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "그레이트파빌리온 하계루프",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/ac69b832cf5d731d27663b85954f4100.jpg",
+    "specs": {},
+    "_productNo": "2932",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2932/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECJ9AR-02ZZ000/KECJ9AR-02ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2935",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "시스템 테이블 사이드 포켓",
+    "color": "",
+    "colorKorean": "블루",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 400,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/65ad3cdaaddb1977ccb9f23b16b7619f.png",
+    "specs": {
+      "material": "폴리에스테르",
+      "packedSize": "41x46cm"
+    },
+    "_productNo": "2935",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2935/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/KECV9FZ-03BL000/KECV9FZ-03BL000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/KECV9FZ-03BL000/KECV9FZ-03BL000_02.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2937",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "ABS 텐트펙 23CM",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/885738488f528d3c45afda04ed0456b6.png",
+    "specs": {},
+    "_productNo": "2937",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2937/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/KECH9AP-03ZZ000/KECH9AP-03ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2958",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "체인 LED랜턴 (오렌지)",
+    "color": "",
+    "colorKorean": "오렌지",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/235aa982dd9029ba97293dac660efbfa.jpg",
+    "specs": {},
+    "_productNo": "2958",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2958/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECV9LT-01OR000/KECV9LT-01OR000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2959",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "체인 LED랜턴 (플린트)",
+    "color": "",
+    "colorKorean": "플린트",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/9b1696a1b6cb042ac93067dd5a9958c1.jpg",
+    "specs": {},
+    "_productNo": "2959",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2959/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECV9LT-01FL000/KECV9LT-01FL000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2961",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "썬더 브라이트2 (그레이)",
+    "color": "",
+    "colorKorean": "그레이",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/d52f190af3e8cb22ff355d1f09f6a624.jpg",
+    "specs": {},
+    "_productNo": "2961",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2961/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECR9LL-04GR000/KECR9LL-04GR000_01.JPG",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECR9LL-04GR000/KECR9LL-04GR000_02.JPG"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2964",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "에어 라이트 테이블 사이드포켓 L",
+    "color": "",
+    "colorKorean": "",
+    "size": "L",
+    "sizeKorean": "라지",
+    "weight": 85,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/571faf2c5c2eda1320d63d60e78ce25c.png",
+    "specs": {
+      "packedSize": "58x30cm"
+    },
+    "_productNo": "2964",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2964/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECN9FZ-01ZZ000/KECN9FZ-01ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2965",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "2웨이 키친테이블 스탠드 Ⅱ",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/dc7fcce81967d2df04acf5a61db4e6fe.png",
+    "specs": {
+      "packedSize": "60x51x51cm"
+    },
+    "_productNo": "2965",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2965/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECN9FZ-02ZZ000/KECN9FZ-02ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2968",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "ML 슬림 3폴딩 테이블",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 6600,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/1f5cafb43c5fd0d771494ccddf3aa200.png",
+    "specs": {},
+    "_productNo": "2968",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2968/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECU9FE-05ZZ000/KECU9FE-05ZZ000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECU9FE-05ZZ000/KECU9FE-05ZZ000_02.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2970",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "3폴딩 테이블 (MDF)",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 6300,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/d4842627a078a743adbadfa83810b089.png",
+    "specs": {
+      "maxLoad": 40,
+      "packedSize": "61x47x10cm"
+    },
+    "_productNo": "2970",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2970/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECV9FM-05ZZ000/KECV9FM-05ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2971",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "GRP시스템 BBQ테이블",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 3500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/250627262c2161471b8241509a171194.png",
+    "specs": {
+      "maxLoad": 30
+    },
+    "_productNo": "2971",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2971/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KECT9FG-02ZZ000/KECT9FG-02ZZ000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2998",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "컨테이너 스토브 캠핑 가스버너",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 739,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/4c541ba19a6ebb71630ab4230cd9c267.jpg",
+    "specs": {},
+    "_productNo": "2998",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2998/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19GS-04S7000/KEC19GS-04S7000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19GS-04S7000/KEC19GS-04S7000_02.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19GS-04S7000/KEC19GS-04S7000_03.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19GS-04S7000/KEC19GS-04S7000_04.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19GS-04S7000/KEC19GS-04S7000_05.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_2999",
+    "category": "pouch",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "베론 스토브(카키) 캐리백 포함",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 1690,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202511/4ed892727c41b1202daefe6a8ade5b11.jpg",
+    "specs": {},
+    "_productNo": "2999",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/2999/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/%BB%F3%BC%BC%C6%E4%C0%CC%C1%F6/%C4%DA%BA%A3%BE%C6/%B0%A1%BD%BA%B1%E2%B1%B8%B7%F9/KECQ9GS-04KH000.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_3016",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "컨테이너 이중연소 화로대",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202509/193b1e7817aef03af5e2a3a2ada2d6b6.jpg",
+    "specs": {},
+    "_productNo": "3016",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/3016/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_3037",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "컨테이너 스토브 블랙 캠핑 버너",
+    "color": "",
+    "colorKorean": "",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 739,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202510/fd0a97a8ddea402befe3a7b798a7e421.jpg",
+    "specs": {},
+    "_productNo": "3037",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/3037/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19GS-14BK000/KEC19GS-14BK000_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19GS-14BK000/KEC19GS-14BK000_03.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19GS-14BK000/KEC19GS-14BK000_05.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19GS-14BK000/KEC19GS-14BK000_09.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_3050",
+    "category": "tent",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "데이토나 팩 해머 캠핑 텐트 망치",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 555,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202510/9792943d4409517c02a4295f9eed9e32.jpg",
+    "specs": {
+      "innerMaterial": "폴리에스테르"
+    },
+    "_productNo": "3050",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/3050/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/KOVEA/2025_09/KEC19AP-01BK000/KEC19AP-01BK000_01.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_3064",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "어라운드 랜턴 스탠드 캠핑 랜턴 거치대",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 450,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/838068b6835c2251eca7b8c3463c87bd.jpg",
+    "specs": {},
+    "_productNo": "3064",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/3064/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/KEC29DT-01BK000/KEC29DT-01BK.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_3173",
+    "category": "table",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "네이쳐하이크 NH 두랄루민 롤 테이블 [브라운]",
+    "color": "",
+    "colorKorean": "브라운",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 7200,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/33b0b127afe0073ffd28e4feb826cc7a.jpg",
+    "specs": {
+      "packedSize": "125x60x43cm",
+      "maxLoad": 50
+    },
+    "_productNo": "3173",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/3173/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/%BB%F3%BC%BC%C6%E4%C0%CC%C1%F6/%B3%D7%C0%CC%C3%B3%C7%CF%C0%CC%C5%A9/%C5%D7%C0%CC%BA%ED%B7%F9/2ECQ9FA-04BW000.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_3193",
+    "category": "lighting",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "네이쳐하이크 NH 2단 캠핑코트 (라이트그레이)",
+    "color": "",
+    "colorKorean": "라이트그레이",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/cf10c4aa548bba28eaea048e33945caa.png",
+    "specs": {},
+    "_productNo": "3193",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/3193/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_3194",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "네이쳐하이크 NH YL11 경량 락킹체어 (카키)",
+    "color": "",
+    "colorKorean": "카키",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/3d882d870096f85cb7b7f4a22e29d6f6.jpg",
+    "specs": {
+      "packedSize": "58x18x20cm",
+      "maxLoad": 150
+    },
+    "_productNo": "3194",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/3194/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/%BB%F3%BC%BC%C6%E4%C0%CC%C1%F6/%B3%D7%C0%CC%C3%B3%C7%CF%C0%CC%C5%A9/%C3%BC%BE%EE%B7%F9/2ECP9CA-04KH000.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_3195",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "네이쳐하이크 NH YL11 경량 락킹체어 (블랙)",
+    "color": "",
+    "colorKorean": "블랙",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/513565bd50d36cd4c0df2feb317c4054.png",
+    "specs": {},
+    "_productNo": "3195",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/3195/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_3196",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "네이쳐하이크 NH YL11 경량 락킹체어 (베이지)",
+    "color": "",
+    "colorKorean": "베이지",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 2500,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/4ffe347ad0e0ec58163cee937ae0a753.jpg",
+    "specs": {
+      "packedSize": "58x18x20cm",
+      "maxLoad": 150
+    },
+    "_productNo": "3196",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/3196/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/%BB%F3%BC%BC%C6%E4%C0%CC%C1%F6/%B3%D7%C0%CC%C3%B3%C7%CF%C0%CC%C5%A9/%C3%BC%BE%EE%B7%F9/2ECP9CA-04BE000.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_3197",
+    "category": "chair",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "네이쳐하이크 NH TY05 4단 각도조절체어 (베이지)",
+    "color": "",
+    "colorKorean": "베이지",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 0,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/7fc6c417c5e2048930d3e33d00b47a3b.png",
+    "specs": {},
+    "_productNo": "3197",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/3197/",
+    "_specImages": [],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_3198",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "네이처하이크 NH 초경량 자충매트 3.5 싱글 L [그레이]",
+    "color": "",
+    "colorKorean": "그레이",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 540,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/93c957cabdfedbbc9997164e500aac29.jpg",
+    "specs": {
+      "material": "나일론",
+      "openSize": "016x27cm"
+    },
+    "_productNo": "3198",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/3198/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/2ECQ9WU-11GR00L/2ECQ9WU-11GR00L_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/2ECQ9WU-11GR00L/2ECQ9WU-11GR00L_02.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/2ECQ9WU-11GR00L/2ECQ9WU-11GR00L_03.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/2ECQ9WU-11GR00L/2ECQ9WU-11GR00L_04.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/2ECQ9WU-11GR00L/2ECQ9WU-11GR00L_05.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/2ECQ9WU-11GR00L/2ECQ9WU-11GR00L_06.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/2ECQ9WU-11GR00L/2ECQ9WU-11GR00L_07.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_3199",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "네이처하이크 NH 초경량 자충매트 3.5 싱글 L [블루]",
+    "color": "",
+    "colorKorean": "블루",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 540,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/ffbc2f4eff870f01ea080d50c2fa66fd.jpg",
+    "specs": {
+      "material": "나일론",
+      "openSize": "016x27cm"
+    },
+    "_productNo": "3199",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/3199/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/2ECQ9WU-11BL00L/2ECQ9WU-11BL00L_01.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/2ECQ9WU-11BL00L/2ECQ9WU-11BL00L_02.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/2ECQ9WU-11BL00L/2ECQ9WU-11BL00L_03.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/2ECQ9WU-11BL00L/2ECQ9WU-11BL00L_04.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/2ECQ9WU-11BL00L/2ECQ9WU-11BL00L_05.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/2ECQ9WU-11BL00L/2ECQ9WU-11BL00L_06.jpg",
+      "https://koveaimage.cafe24.com/KOVEA/2024_10/2ECQ9WU-11BL00L/2ECQ9WU-11BL00L_07.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  },
+  {
+    "groupId": "kovea_3202",
+    "category": "mat",
+    "company": "kovea",
+    "companyKorean": "코베아",
+    "name": "",
+    "nameKorean": "네이쳐하이크 NH 차박용 멀티 에어매트 (에어펌프 포함) [베이지]",
+    "color": "",
+    "colorKorean": "베이지",
+    "size": "",
+    "sizeKorean": "",
+    "weight": 4000,
+    "imageUrl": "https://www.kovea.co.kr/web/product/big/202603/44ffdc40033f13266927e5eae832e11c.jpg",
+    "specs": {
+      "openSize": "182x130x13cm"
+    },
+    "_productNo": "3202",
+    "_detailUrl": "https://www.kovea.co.kr/product/x/3202/",
+    "_specImages": [
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_1.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_2.jpg",
+      "https://koveaimage.cafe24.com/PRODUCT/notice/notice_3.jpg",
+      "https://koveaimage.cafe24.com/%BB%F3%BC%BC%C6%E4%C0%CC%C1%F6/%B3%D7%C0%CC%C3%B3%C7%CF%C0%CC%C5%A9/%B8%C5%C6%AE%B7%F9/2ECQ9WA-15BE000.jpg"
+    ],
+    "_source": "sitemap",
+    "_discontinued": true
+  }
+]

--- a/.claude/skills/crawl-gear/sites/kovea.js
+++ b/.claude/skills/crawl-gear/sites/kovea.js
@@ -1,0 +1,215 @@
+// Kovea (코베아) — kovea.co.kr, Cafe24 shopping mall. Korean camping brand.
+// Listing: /product/list.html?cate_no=N&page=P  (JS-rendered grid → puppeteer)
+//   product cards: ul.prductList li, detail links /product/<korean-slug>/<no>/...
+// Detail spec is embedded in tall description IMAGES on koveaimage.cafe24.com
+//   (KOVEA/<YYYY_MM>/<CODE>/<CODE>_NN.jpg). Specs live in the Korean "상품 정보 제공 고시"
+//   table (and sometimes an English "Specification" block) near the BOTTOM of the last
+//   image. The adapter only collects listing + `_specImages`; OCR extraction of weight/
+//   specs is a separate step → kovea-specs.py (fills weight + specs on the crawl JSON).
+const BASE = 'https://www.kovea.co.kr';
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+// cate_no → internal category key (major categories first)
+const CATEGORY_MAP = {
+  588: 'tent', 901: 'tent', 587: 'tent',
+  602: 'tarp',
+  596: 'tent_acc', 665: 'tent_acc',
+  607: 'chair',
+  612: 'table',
+  641: 'sleeping_bag',
+  644: 'mat',
+  624: 'lighting', 670: 'lighting',
+  619: 'stove',
+  631: 'torch',
+  628: 'etc', 634: 'etc',
+  650: 'cookware_etc', 654: 'cookware_etc', 659: 'cookware_etc',
+  661: 'pouch',
+  669: 'etc', 674: 'etc',
+};
+
+const catOf = (url) => {
+  const m = String(url).match(/cate_no=(\d+)/);
+  return m ? (CATEGORY_MAP[Number(m[1])] ?? 'etc') : 'etc';
+};
+
+const slugToName = (slug) =>
+  decodeURIComponent(slug).replace(/-/g, ' ').replace(/\s+/g, ' ').trim();
+
+const SIZE_KO = {
+  XS: '엑스스몰', S: '스몰', M: '미디엄', L: '라지', XL: '엑스라지',
+  XXL: '투엑스라지', '2XL': '투엑스라지', '3XL': '쓰리엑스라지',
+};
+// Kovea ships each colour/size as its own product, baking the variant into the name —
+// e.g. "아모르 Ⅱ M (다크그레이)", "가죽 테이블보 M", "T코어 (블랙)". Pull them out.
+const COLOR_KW = ['다크그레이', '라이트그레이', '그레이지', '그레이', '차콜', '블랙', '화이트', '아이보리',
+  '카키그린', '카키', '카모', '다크네이비', '네이비', '세이지', '올리브', '포레스트', '그린',
+  '스카이블루', '블루', '레드', '오렌지', '옐로우', '머스타드', '다크브라운', '브라운', '코요테',
+  '모카', '크림', '샌드', '탄', '베이지', '핑크', '퍼플', '라벤더', '버건디', '와인', '골드', '실버', '민트', '코랄'];
+const findColor = (s) => COLOR_KW.find((c) => s === c || s.includes(c)) || '';
+const extractVariant = (name) => {
+  let color = '';
+  let base = name;
+  const paren = name.match(/\(([^)]+)\)\s*$/);
+  if (paren) {
+    const c = findColor(paren[1].trim());
+    if (c) { color = paren[1].trim(); base = name.replace(/\s*\([^)]*\)\s*$/, '').trim(); }
+  }
+  if (!color) {
+    const last = base.split(/\s+/).pop();
+    if (last && findColor(last) === last) { color = last; base = base.replace(/\s+\S+$/, '').trim(); }
+  }
+  const sm = base.match(/\s(XS|S|M|L|XL|XXL|2XL|3XL)$/i);
+  return { color, size: sm ? sm[1].toUpperCase() : '' };
+};
+
+// Fetch the detail page: real Korean name (og:title — keeps '.', '~' that the URL slug
+// drops) + the koveaimage CDN description image sequence.
+const fetchDetail = async (productNo) => {
+  try {
+    const r = await fetch(`${BASE}/product/x/${productNo}/`, { headers: { 'User-Agent': UA } });
+    const html = await r.text();
+    const nm = html.match(/<meta[^>]*property=["']og:title["'][^>]*content=["']([^"']+)["']/i)
+      || html.match(/content=["']([^"']+)["'][^>]*property=["']og:title["']/i);
+    const name = nm ? nm[1].replace(/\s*-\s*코베아\s*$/, '').replace(/\s+/g, ' ').trim() : '';
+    // Detail/description images live on the koveaimage CDN OR /web/upload (NNEditor etc.).
+    // Collect both; drop UI chrome (icons, menus, banners, tiny custom_*, list thumbnails).
+    const imgs = [];
+    for (const m of html.matchAll(/koveaimage\.cafe24\.com\/[^"'\s)]+\.(?:jpg|jpeg|png)/gi)) {
+      imgs.push('https://' + m[0]);
+    }
+    for (const m of html.matchAll(/(?:src|ec-data-src)=["']([^"']*?\/web\/upload\/[^"']+\.(?:jpg|jpeg|png))/gi)) {
+      let u = m[1];
+      if (/\/category\/|icon|menu|btn|common|custom_\d|sns_|logo/i.test(u)) continue;
+      if (u.startsWith('//')) u = 'https:' + u;
+      else if (u.startsWith('/')) u = BASE + u;
+      imgs.push(u);
+    }
+    return { name, specImages: [...new Set(imgs)] };
+  } catch {
+    return { name: '', specImages: [] };
+  }
+};
+
+const extractListing = async (page) =>
+  page.evaluate(() => {
+    const lis = [...document.querySelectorAll('ul.prductList > li')];
+    const out = [];
+    for (const li of lis) {
+      const a = li.querySelector('a[href*="/product/"]');
+      if (!a) continue;
+      const m = a.getAttribute('href').match(/\/product\/([^/]+)\/(\d+)\//);
+      if (!m) continue;
+      const slug = m[1];
+      if (['big', 'medium', 'small', 'tiny'].includes(slug) || /^\d+$/.test(slug)) continue;
+      const img = li.querySelector('img');
+      let imageUrl = img ? (img.getAttribute('ec-data-src') || img.getAttribute('src') || '') : '';
+      imageUrl = imageUrl.replace(/^\/\//, 'https://').split('?')[0];
+      if (imageUrl.startsWith('/')) imageUrl = location.origin + imageUrl;
+      out.push({ no: m[2], slug, imageUrl });
+    }
+    return out;
+  });
+
+const getMaxPage = async (page) =>
+  page.evaluate(() => {
+    const nums = [...document.querySelectorAll('.xans-product-normalpaging a, [class*="paging"] a, .ec-base-paginate a')]
+      .map((a) => parseInt(a.textContent.trim(), 10)).filter((n) => !Number.isNaN(n));
+    return nums.length ? Math.max(...nums) : 1;
+  });
+
+const crawlCategory = async (browser, categoryUrl) => {
+  const category = catOf(categoryUrl);
+  const page = await browser.newPage();
+  await page.setUserAgent(UA);
+  await page.setViewport({ width: 1280, height: 1000 });
+
+  const seen = new Map(); // no → {slug, imageUrl}
+  try {
+    await page.goto(categoryUrl, { waitUntil: 'networkidle2', timeout: 60000 });
+    await page.waitForSelector('ul.prductList > li', { timeout: 15000 }).catch(() => {});
+    const maxPage = await getMaxPage(page);
+    for (let p = 1; p <= maxPage; p++) {
+      if (p > 1) {
+        const u = new URL(categoryUrl);
+        u.searchParams.set('page', String(p));
+        await page.goto(u.toString(), { waitUntil: 'networkidle2', timeout: 60000 });
+        await page.waitForSelector('ul.prductList > li', { timeout: 15000 }).catch(() => {});
+      }
+      await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+      await new Promise((r) => setTimeout(r, 800));
+      const items = await extractListing(page);
+      let fresh = 0;
+      for (const it of items) {
+        if (it.slug === '트랜스업세트') continue; // pinned promo repeated on every page
+        if (!seen.has(it.no)) { seen.set(it.no, it); fresh++; }
+      }
+      console.log(`[kovea]   ${category} page ${p}/${maxPage}: +${fresh} (total ${seen.size})`);
+      if (p > 1 && fresh === 0) break;
+    }
+  } catch (e) {
+    console.log(`[kovea] listing error ${categoryUrl}: ${e.message}`);
+  } finally {
+    await page.close();
+  }
+
+  const results = [];
+  let i = 0;
+  for (const [no, it] of seen) {
+    i++;
+    const detail = await fetchDetail(no);
+    if (i % 10 === 0) console.log(`[kovea]   ${category} detail ${i}/${seen.size}`);
+    // nameKorean = real product name (og:title); English name left empty (Korean brand).
+    const nameKorean = detail.name || slugToName(it.slug);
+    const { color, size } = extractVariant(nameKorean);
+    results.push({
+      groupId: `kovea_${no}`,
+      category,
+      company: 'kovea',
+      companyKorean: '코베아',
+      name: '',
+      nameKorean,
+      color: '',
+      colorKorean: color,
+      size,
+      sizeKorean: size ? (SIZE_KO[size] || size) : '',
+      weight: 0,
+      imageUrl: it.imageUrl,
+      specs: {},
+      _productNo: no,
+      _detailUrl: `${BASE}/product/${it.slug}/${no}/`,
+      _specImages: detail.specImages,
+      _source: categoryUrl,
+    });
+  }
+  return results;
+};
+
+export default {
+  name: 'kovea',
+  company: 'kovea',
+  baseUrl: BASE,
+  defaultCategories: [
+    `${BASE}/product/list.html?cate_no=588`, // 텐트
+    `${BASE}/product/list.html?cate_no=602`, // 타프
+    `${BASE}/product/list.html?cate_no=607`, // 체어
+    `${BASE}/product/list.html?cate_no=612`, // 테이블
+    `${BASE}/product/list.html?cate_no=641`, // 침낭
+    `${BASE}/product/list.html?cate_no=644`, // 매트
+    `${BASE}/product/list.html?cate_no=670`, // 랜턴
+  ],
+  crawl: async (browser, { categoryUrls } = {}) => {
+    const urls = categoryUrls?.length ? categoryUrls : [`${BASE}/product/list.html?cate_no=588`];
+    const all = [];
+    for (const url of urls) {
+      console.log(`[kovea] crawling ${url}`);
+      try {
+        const items = await crawlCategory(browser, url);
+        console.log(`[kovea] ${items.length} items from ${url}`);
+        all.push(...items);
+      } catch (e) {
+        console.log(`[kovea] error on ${url}: ${e.message} — skipping`);
+      }
+    }
+    return all;
+  },
+};


### PR DESCRIPTION
## 개요
코베아(Cafe24)는 무게·크기·재질·온도가 **본문 텍스트가 아니라 긴 상세 이미지** 안에 있어, macOS Vision OCR(한국어)로 스펙을 추출하는 파이프라인을 구축했습니다. 품절·옵션 변형 포함 317개.

## 신규 도구
- **`sites/kovea.js`** — 리스팅(puppeteer) + og:title 제품명 + 상세 이미지 수집(koveaimage CDN + `/web/upload`), 이름 대괄호에서 색상/사이즈 변형
- **`ocr.py`** — macOS Vision OCR (ko-KR fast 레벨, 긴 이미지 타일 분할)
- **`kovea-specs.py`** — 상품정보제공고시/Specification 표 파싱(크기·중량·재질·수용인원·내수압) + PFAS 고지문 제거
- **`kovea-fixweight.py`** — 위치기반 OCR로 라벨↔값 행 정렬 (컬럼 레이아웃에서 내하중을 무게로 오인하던 문제 해결)
- **`kovea-sleeptemp.py`** — 침낭 ISO 23537 / 3단계 온도표(이미지 중간)
- **`kovea-imgcolor.py`** — 이미지 "색상" 항목에서 색상(단일만)
- **`kovea-options.js`** — Cafe24 색상/사이즈 옵션 셀렉트 → 변형 분리
- **`kovea-sitemap-add.js`** — 사이트맵으로 품절 포함 전체 제품 수집
- **`SKILL.md`** — 이미지 OCR 워크플로우, Cafe24+이미지 사이트 유형, push `_source` 주의, pyobjc 의존성

## 데이터
- `out/kovea-full.json` — 317개 (품절·옵션변형 포함). Firestore 반영 완료(inserted 317).
- 카테고리: tent 55, table 57, chair 56, mat 42, lighting 39, tent_acc 29, pouch 15, tarp 14, sleeping_bag 10

## 핵심 교훈 (문서화)
한국어 OCR은 fast 레벨만 지원 · 긴 이미지는 타일 분할 필수 · 위치기반 라벨↔값 정렬 · 색상 3소스 결합(대괄호+이미지+옵션) · 사이트맵으로 품절 포함 · 무게 0은 데이터 부재 구분

🤖 Generated with [Claude Code](https://claude.com/claude-code)