### PR TITLE
엑스패드(Exped) 크롤 어댑터 + 색상/무게 OCR

### DIFF
--- a/.claude/skills/crawl-gear/brands/exped.md
+++ b/.claude/skills/crawl-gear/brands/exped.md
@@ -1,0 +1,22 @@
+# 엑스패드 (exped)
+
+- **한국 공식**: https://exped.co.kr  (Cafe24, 매트·텐트·침낭·백팩 등 기어 브랜드)
+- **국제 공식**: https://www.exped.com/en  (커스텀 CMS, 제품 페이지에 구조화 스펙 — 무게 소스)
+- 크롤러: `exped.py` (KR 크롤 + EN 스펙 음역매칭), EN 스펙 캐시 `out/exped-en-cache.json`
+- 마지막 크롤: 2026-07, 약 340행(제품 164)
+
+## ⚠️ 주의사항
+1. **KR 카테고리 8개**(텐트24·매트25·백팩26·스토리지27·침낭28·베개42·해먹43·액세서리44) 모두 순회.
+   풋프린트→tent_acc, 레인커버→backpack_cover, 스트랩/카라비너 등→etc 로 보정.
+2. **사이즈 옵션(M/LW/MW 등)은 상세 옵션 select 에 있다.** 첫 옵션이 "선택하세요" 플레이스홀더 →
+   거기서 멈추지 말고 skip, "SHIPPING TO" 나오면 종료. **옵션에 색상이 섞임**(예 'S-M-블랙') →
+   색상 토큰 분리해서 color 로, 나머지를 size 로.
+3. **무게는 KR 텍스트에 없다.** 국제 사이트(exped.com/en) 제품 페이지의 `<h4>라벨</h4><div>값</div>`
+   블록에서 파싱:
+   - 매트/침낭/백팩: `Weight`(사이즈별 "M: 1010 g | LW: 1415 g" 형태 — KR 사이즈옵션과 매칭).
+   - **텐트: `Max. Weight`(패킹) 우선, `Min. Weight`(최소)는 폴백.** (라벨이 'Weight' 아님 주의!)
+   - R-Value, Temperature(℃), Volume(L), Thickness, Person Capacity 도 같은 구조.
+4. **KR↔EN 매칭 = 음역(MODEL_EN) + 숫자.** 버사→versa, 씸→sim, 플렉스→flex, 울트라→ultra, 테라→terra,
+   두라/듀라→dura, 토렌트→torrent, 스카이라인→skyline 등. **텐트 인용수는 EN 이 로마숫자**(3→iii) →
+   arabic/roman 둘 다 시도. 매칭 안 되면 무게 없음(KR 전용 모델·음역 미등재).
+5. num_key 에 사이즈(M/LW)를 넣지 말 것 — 무게는 wmap[size] 로 별도 매칭.

--- a/.claude/skills/crawl-gear/exped-color-ocr.py
+++ b/.claude/skills/crawl-gear/exped-color-ocr.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# 엑스패드 색상 OCR — 색상 없는 제품의 상세설명 이미지(/web/upload/NNEditor/)에
+# "색상 : ● 메로우" 형태로 색상이 있음(텍스트 아님·이미지). macOS Vision OCR 로 추출.
+# 대상: KR 소스 + color=='' 인 제품(groupId 단위). color(영문)+colorKorean(한글) 채움.
+# 사용: python3 exped-color-ocr.py out/exped-FINAL.json
+import io
+import json
+import re
+import subprocess
+import sys
+
+from PIL import Image
+
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+COLOR_EN = {
+    "메로우": "Mallow", "모스": "Moss", "다크라바": "Dark Lava", "블랙": "Black", "네이비": "Navy",
+    "그레이": "Grey", "골드": "Gold", "세이지": "Sage", "버건디": "Burgundy", "포레스트": "Forest",
+    "모레인": "Moraine", "사이프러스": "Cypress", "움브라": "Umbra", "라이켄": "Lichen", "루비": "Ruby",
+    "테라코타": "Terracotta", "화이트": "White", "블루": "Blue", "카키": "Khaki", "그린": "Green",
+    "오션": "Ocean", "썬버스트": "Sunburst", "포그": "Fog", "어버진": "Aubergine", "아이벡스": "Ibex",
+    "트라우트": "Trout", "마멋": "Marmot", "플레임": "Flame", "다크헤나": "Dark Henna",
+    "그레이구스": "Grey Goose", "레드": "Red", "오렌지": "Orange", "옐로": "Yellow", "실버": "Silver",
+    "차콜": "Charcoal", "브라운": "Brown", "베이지": "Beige", "아이보리": "Ivory", "민트": "Mint",
+    "테라": "Terra", "선셋": "Sunset", "스톰": "Storm", "코랄": "Coral", "라임": "Lime",
+    "올리브": "Olive", "틸": "Teal", "로즈": "Rose", "샌드": "Sand", "포피": "Poppy",
+}
+
+
+def curl_bytes(url, ref="https://exped.co.kr/"):
+    try:
+        return subprocess.run(["curl", "-sS", "-m", "25", "-A", UA, "-e", ref, url],
+                              capture_output=True, timeout=30).stdout
+    except Exception:
+        return b""
+
+
+def curl_text(url):
+    return curl_bytes(url).decode("utf-8", "replace")
+
+
+def detail_images(product_no):
+    t = curl_text(f"https://exped.co.kr/product/detail.html?product_no={product_no}")
+    paths = re.findall(r'(?:src|ec-data-src|data-src)=["\']([^"\']*?/web/upload/NNEditor/[^"\']+\.(?:jpg|jpeg|png))', t, re.I)
+    out = []
+    for p in dict.fromkeys(paths):
+        if p.startswith("//"):
+            p = "https:" + p
+        elif p.startswith("/"):
+            p = "https://exped.co.kr" + p
+        out.append(p)
+    return out
+
+
+def ocr_lines(raw):
+    try:
+        im = Image.open(io.BytesIO(raw)).convert("RGB")
+    except Exception:
+        return []
+    W, H = im.size
+    lines = []
+    for top in range(0, H, 1400):
+        im.crop((0, top, W, min(top + 1500, H))).save("/tmp/_ecol.jpg")
+        try:
+            items = json.loads(subprocess.run(["python3", "ocr.py", "/tmp/_ecol.jpg"],
+                                              capture_output=True, timeout=60).stdout.decode("utf-8", "replace"))
+            lines += [it["t"] for it in items]
+        except Exception:
+            continue
+    return lines
+
+
+def parse_color(lines):
+    for ln in lines:
+        m = re.search(r"색상\s*[:：]?\s*[●•·]?\s*([가-힣][가-힣A-Za-z /]*)", ln)
+        if m:
+            val = m.group(1).strip()
+            # 안내문/마케팅 문장 오추출 제외(예: "색상과 디자인으로 업데이트 되었습니다")
+            if re.search(r"교환|변경|선택|참고|이미지|되었|제공|업데이트|디자인|니다|^과$|^만$", val) or len(val) > 7:
+                continue
+            # 멀티컬러 "/" 분리
+            parts = [p.strip() for p in re.split(r"[/,]", val) if p.strip()][:1]  # 대표(첫) 색상
+            return parts[0] if parts else ""
+    return ""
+
+
+def main():
+    path = sys.argv[1]
+    rows = json.load(open(path))
+    by_no = {}
+    for r in rows:
+        if "exped.co.kr" in r["_source"] and not any(x["color"] for x in rows if x["groupId"] == r["groupId"]):
+            no = re.search(r"product_no=(\d+)", r["_source"]).group(1)
+            by_no.setdefault(no, []).append(r)
+    print(f"색상 없는 제품(product_no): {len(by_no)}", flush=True)
+    filled = 0
+    for i, (no, rs) in enumerate(by_no.items(), 1):
+        lines = []
+        for u in detail_images(no):
+            raw = curl_bytes(u)
+            if raw[:3] != b"\xff\xd8\xff" and raw[:4] != b"\x89PNG":
+                continue
+            lines += ocr_lines(raw)
+            if any("색상" in ln for ln in lines):
+                break  # 색상 찾으면 조기 종료
+        ko = parse_color(lines)
+        if ko:
+            en = " ".join(COLOR_EN.get(w, w) for w in ko.split())
+            for r in rs:
+                r["color"] = en
+                r["colorKorean"] = ko
+            filled += 1
+        if i % 10 == 0 or i == len(by_no):
+            print(f"  {i}/{len(by_no)} (색상 {filled})", flush=True)
+    json.dump(rows, open(path, "w"), ensure_ascii=False, indent=2)
+    print(f"완료: 색상 채운 제품 {filled} -> {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/crawl-gear/exped-weight-ocr.py
+++ b/.claude/skills/crawl-gear/exped-weight-ocr.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+# 엑스패드 무게 OCR — EN 매칭이 안 된 매트/침낭/텐트의 무게를 KR 상세설명 이미지의
+# Tech Specs 표(사이즈별 "M 220cm ... 300g")에서 추출. 대상: mat/sleeping_bag/tent + weight==0.
+# 사용: python3 exped-weight-ocr.py out/exped-FINAL.json
+import io
+import json
+import re
+import subprocess
+import sys
+
+from PIL import Image
+
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+TARGET = {"mat", "sleeping_bag", "tent"}
+SIZE_ALIAS = {"미디엄": "M", "라지": "L", "스몰": "S", "롱": "LW", "와이드": "W", "우노": "Uno", "듀오": "Duo",
+              "UNO": "Uno", "DUO": "Duo", "TRIO": "Trio", "QUEEN": "Queen"}
+# 주의: 정규식 교대(|)는 '먼저 나온 것' 우선이므로 긴/복합 사이즈를 앞에 둔다(MW 가 M+W 로 쪼개지지 않게).
+SIZE_HEAD = r"(?:LXW|MW\+|LW\+|XXL|XL|XS|MW|LW|SW|Uno|Duo|Trio|Queen|UNO|DUO|TRIO|QUEEN|우노|듀오|트리오|미디엄|라지|스몰|S|M|L|W)"
+
+
+def cb(u, ref="https://exped.co.kr/"):
+    try:
+        return subprocess.run(["curl", "-sS", "-m", "25", "-A", UA, "-e", ref, u],
+                              capture_output=True, timeout=30).stdout
+    except Exception:
+        return b""
+
+
+def detail_lines(product_no):
+    t = cb(f"https://exped.co.kr/product/detail.html?product_no={product_no}").decode("utf-8", "replace")
+    imgs = re.findall(r'(?:src|ec-data-src|data-src)=["\']([^"\']*?/web/upload/NNEditor/[^"\']+\.(?:jpg|jpeg|png))', t, re.I)
+    urls = []
+    for p in dict.fromkeys(imgs):
+        urls.append("https:" + p if p.startswith("//") else ("https://exped.co.kr" + p if p.startswith("/") else p))
+    lines = []
+    for u in urls:
+        raw = cb(u)
+        if raw[:3] != b"\xff\xd8\xff" and raw[:4] != b"\x89PNG":
+            continue
+        try:
+            im = Image.open(io.BytesIO(raw)).convert("RGB")
+        except Exception:
+            continue
+        W, H = im.size
+        for top in range(0, H, 1400):
+            im.crop((0, top, W, min(top + 1500, H))).save("/tmp/_ewt.jpg")
+            try:
+                items = json.loads(subprocess.run(["python3", "ocr.py", "/tmp/_ewt.jpg"],
+                                                  capture_output=True, timeout=60).stdout.decode("utf-8", "replace"))
+            except Exception:
+                continue
+            items.sort(key=lambda x: (round(x["y"], 2), x["x"]))
+            cy, cur = None, []
+            for it in items:
+                if cy is None or abs(it["y"] - cy) < 0.012:
+                    cur.append(it["t"]); cy = it["y"] if cy is None else cy
+                else:
+                    lines.append(" ".join(cur)); cur = [it["t"]]; cy = it["y"]
+            if cur:
+                lines.append(" ".join(cur))
+    return lines
+
+
+def _g(val, unit):
+    v = float(val.replace(",", ""))
+    return round(v * 1000) if unit.lower() == "kg" else round(v)
+
+
+def _grams(s):
+    out = []
+    for x in re.findall(r"(\d[\d,]*)\s*g\b", s):
+        v = int(x.replace(",", ""))
+        if 30 <= v <= 30000:
+            out.append(v)
+    return out
+
+
+def parse_weights(lines):
+    """사이즈별 무게 → {size: grams}. 두 표 형식 지원:
+      (A) 행형(침낭): 'M 220cm 178cm ... 300g'
+      (B) 매트형: 'M 사이즈' 헤더 → 값라인 '0°C 2.4 5cm 183x52x52cm 595 g ...'"""
+    res = {}
+    cur = None
+    for ln in lines:
+        # (B) 사이즈 헤더 "M 사이즈" / "LW 사이즈", 또는 단독 사이즈 블록 헤더 "MW"/"LW"/"LXW"
+        #   단독 헤더는 2글자 이상 사이즈만 허용(단일 S/M/L/W 는 노이즈 오인 방지 위해 '사이즈' 필요).
+        mh = re.match(r"^\s*(" + SIZE_HEAD + r")\s*사이즈\s*$", ln)
+        if not mh:
+            mb = re.match(r"^\s*(" + SIZE_HEAD + r")\s*$", ln)
+            if mb and len(mb.group(1)) >= 2:
+                mh = mb
+        if mh:
+            cur = SIZE_ALIAS.get(mh.group(1), mh.group(1))
+            continue
+        # (B) 값라인: 직전 사이즈 헤더가 있고 'N g' + cm 이 있으면 무게
+        if cur and re.search(r"cm", ln):
+            mg = re.search(r"([\d.,]+)\s*(kg|g)\b", ln)
+            if mg:
+                g = _g(mg.group(1), mg.group(2))
+                if 50 <= g <= 30000:
+                    res.setdefault(cur, g)
+                cur = None
+                continue
+        # (A) 행형: 사이즈로 시작 + cm dimensions + Ng
+        m = re.match(r"^\s*(" + SIZE_HEAD + r")\b(.*?)([\d.,]+)\s*(kg|g)\b", ln)
+        if m and ("cm" in m.group(2)):
+            sz = SIZE_ALIAS.get(m.group(1), m.group(1))
+            g = _g(m.group(3), m.group(4))
+            if 30 <= g <= 30000:
+                res.setdefault(sz, g)
+    # (D) 컬럼형 표: '사이즈 MW LW LXW' 헤더행 + 무게행('무게'/'무낵 게' + 사이즈수만큼 그램)
+    #   '사이즈'가 '사 이 즈'로, '무게'가 '무낵 게'로 깨져도 대응. 순수 그램/oz쌍 모두 지원.
+    col = None
+    for ln in lines:
+        mh = re.match(r"^\s*사\s*이\s*즈\s*[:：]?\s*(.+)", ln)
+        if mh:
+            c = re.findall(SIZE_HEAD, mh.group(1))
+            col = c if len(c) >= 2 else None
+            continue
+        if col and re.match(r"^\s*무", ln) and "충전" not in ln:
+            gs = _grams(ln)
+            if len(gs) >= len(col):
+                for sz, g in zip(col, gs):
+                    res.setdefault(SIZE_ALIAS.get(sz, sz), g)
+            col = None
+    # (D') 헤더가 깨진 컬럼형(워터블록): 무게행에 oz쌍 → 그램 값 개수로 사이즈 추론(3→S/M/L).
+    if not res:
+        for ln in lines:
+            mw = re.match(r"^\s*무게\s+(.+)", ln)
+            if mw and "충전" not in ln and "/" in ln:
+                gs = _grams(mw.group(1))
+                col = {2: ["M", "L"], 3: ["S", "M", "L"], 4: ["S", "M", "L", "XL"]}.get(len(gs))
+                if col:
+                    for sz, g in zip(col, gs):
+                        res.setdefault(SIZE_ALIAS.get(sz, sz), g)
+                    break
+    # (E) 단일 사이즈: '단일사이즈' 표기 + '무게' 단일 그램값 → 키 '' (본문 폴백이 사용)
+    if not res and any(re.search(r"단일\s*사이즈", ln) for ln in lines):
+        for ln in lines:
+            if "무게" in ln and not re.search(r"충전|패킹|포장", ln):
+                gs = _grams(ln)
+                if len(gs) == 1:
+                    res[""] = gs[0]
+                    break
+    # (F) 텐트/단일 라벨형 무게: 최대무게(패킹) > 최소무게 > '무게 : Ng'. 원단 무게(g/m²)는 제외.
+    if not res:
+        text = "\n".join(lines)
+        for pat in [r"최대\s*무게\s*[:：(]?\s*(?:약\s*)?([\d.,]+)\s*(kg|g)\b",
+                    r"최소\s*무게\s*[:：(]?\s*(?:약\s*)?([\d.,]+)\s*(kg|g)\b",
+                    r"(?:^|[\s\-])무게\s*[:：]?\s*(?:약\s*)?([\d.,]+)\s*(kg|g)(?!\s*/?\s*m)"]:
+            m = re.search(pat, text)
+            if m:
+                if m.group(2).lower() == "kg" and float(m.group(1).replace(",", "")) > 30:
+                    continue  # OCR 소수점 유실 방어
+                g = _g(m.group(1), m.group(2))
+                if 30 <= g <= 30000:
+                    res[""] = g
+                    break
+    return res
+
+
+def parse_temp(lines):
+    for ln in lines:
+        m = re.search(r"(?:쾌적|한계)\s*온도.*?(-?\d+)\s*[℃도C]", ln)
+        if m:
+            return int(m.group(1))
+    return None
+
+
+def main():
+    path = sys.argv[1]
+    rows = json.load(open(path))
+    by_no = {}
+    for r in rows:
+        if r["category"] in TARGET and "exped.co.kr" in r["_source"] and not r["weight"]:
+            no = re.search(r"product_no=(\d+)", r["_source"]).group(1)
+            by_no.setdefault(no, []).append(r)
+    print(f"무게 없는 매트/침낭/텐트(product_no): {len(by_no)}", flush=True)
+    fw = 0
+    for i, (no, rs) in enumerate(by_no.items(), 1):
+        lines = detail_lines(no)
+        wmap = parse_weights(lines)
+        temp = parse_temp(lines) if rs[0]["category"] == "sleeping_bag" else None
+        got = False
+        for r in rs:
+            sz = r["size"]
+            w = wmap.get(sz)
+            if not w and wmap:
+                w = next(iter(wmap.values())) if len(wmap) == 1 else min(wmap.values())
+            if w:
+                r["weight"] = w
+                got = True
+            if temp is not None and "limitTemp" not in r["specs"]:
+                r["specs"] = {**r["specs"], "limitTemp": temp}
+        if got:
+            fw += 1
+        if i % 5 == 0 or i == len(by_no):
+            print(f"  {i}/{len(by_no)} (무게 {fw})", flush=True)
+    json.dump(rows, open(path, "w"), ensure_ascii=False, indent=2)
+    print(f"완료: 무게 채운 제품 {fw} -> {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/crawl-gear/exped.py
+++ b/.claude/skills/crawl-gear/exped.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+# 엑스패드 크롤 — 2소스 하이브리드 (시에라디자인 패턴과 동일).
+#  (A) 한국 공식(exped.co.kr, Cafe24): 전 제품(한글명·사이즈옵션·색상·이미지). 무게는 텍스트에 없음.
+#  (B) 국제 공식(www.exped.com/en): 제품 페이지에 구조화 스펙(Weight/R-Value/Temperature/치수).
+#      KR 이름을 영문 모델로 음역 + 숫자(R값·온도)로 EN 제품과 매칭해 무게/스펙 보강.
+# 사용: python3 exped.py out/exped-FINAL.json
+import html
+import json
+import re
+import subprocess
+import sys
+import time
+
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+KR = "https://exped.co.kr"
+EN = "https://www.exped.com"
+
+
+def curl(url, follow=False):
+    time.sleep(0.1)
+    args = ["curl", "-sS", "-m", "30", "-A", UA]
+    if follow:
+        args.append("-L")
+    for _ in range(3):
+        out = subprocess.run(args + [url], capture_output=True, timeout=35)
+        if out.returncode == 0:
+            return out.stdout.decode("utf-8", "replace")
+        time.sleep(1)
+    return ""
+
+
+# ── 카테고리 ───────────────────────────────────────────────────────
+KR_CATS = {24: "tent", 25: "mat", 26: "backpack", 27: "pouch",
+           28: "sleeping_bag", 42: "pillow", 43: "etc", 44: "etc"}
+
+
+def refine_cat(cat, name):
+    if re.search(r"풋프린트|그라운드시트|풋 프린트", name):
+        return "tent_acc"
+    if re.search(r"레인\s*커버|레인커버", name):
+        return "backpack_cover"
+    if re.search(r"스트랩|클립|카라비너|로프|리페어|패치|펌프|밸브|어댑터|워시|클리너", name):
+        return "etc"
+    return cat
+
+
+# ── 색상 음역(엑스패드는 색상변형 드묾, 이름 말미 영문색상만) ─────────────
+COLOR_KOR = {"black": "블랙", "grey": "그레이", "gray": "그레이", "green": "그린", "blue": "블루",
+             "red": "레드", "orange": "오렌지", "yellow": "옐로", "navy": "네이비", "charcoal": "차콜",
+             "ruby": "루비", "terracotta": "테라코타", "lichen": "라이켄", "cypress": "사이프러스"}
+
+
+def color_kor(en):
+    if not en:
+        return ""
+    return " ".join(COLOR_KOR.get(w.lower(), w) for w in en.split())
+
+
+def slugify(s):
+    return "exped_" + re.sub(r"[^a-z0-9가-힣]+", "-", re.sub(r"[™®()\[\]]", " ", s).strip().lower()).strip("-")
+
+
+# ── (A) KR 크롤 ────────────────────────────────────────────────────
+def kr_sizes(product_no):
+    """상세 옵션 select 에서 사이즈(M/LW 등) 추출. 'SHIPPING TO' 이전의 옵션만."""
+    t = curl(f"{KR}/product/detail.html?product_no={product_no}")
+    opts = re.findall(r"<option[^>]*>([^<]+)</option>", t)
+    sizes = []
+    for o in opts:
+        o = html.unescape(o).strip()
+        if "SHIPPING TO" in o:
+            break  # 배송국가 목록 시작 → 사이즈 옵션 끝
+        if "선택" in o or set(o) <= set("- ") or not o:
+            continue  # 플레이스홀더/구분선 스킵
+        s = re.sub(r"\s*[\[(].*$", "", o).strip()  # "[품절]"/"(+원)" 제거
+        if s and s not in sizes:
+            sizes.append(s)
+    return sizes
+
+
+def crawl_kr(with_sizes=True):
+    rows = []
+    seen = set()
+    for cno, cat0 in KR_CATS.items():
+        page = 1
+        while page <= 30:
+            t = curl(f"{KR}/category/all/{cno}/?page={page}")
+            blocks = re.split(r"anchorBoxId_", t)[1:]
+            if not blocks:
+                break
+            added = 0
+            for b in blocks:
+                mo = re.match(r"(\d+)", b)
+                if not mo:
+                    continue
+                no = mo.group(1)
+                if no in seen:
+                    continue
+                alt = re.search(r'alt="([^"]+)"', b)
+                price = re.search(r'ec-data-price="(\d+)"', b)
+                if not alt or not price or price.group(1) == "0":
+                    continue
+                name = html.unescape(alt.group(1)).strip()
+                # 이미지 alt 설명(" - ... 이미지" / "... 제품 이미지") 정리
+                if name.endswith("이미지"):
+                    if " - " in name:
+                        name = name.split(" - ")[0].strip()
+                    else:
+                        name = re.sub(r"\s*(EXPED\s*)?(제품\s*)?이미지$", "", name).strip()
+                name = re.sub(r"^EXPED\s+", "", name).strip()
+                if re.search(r"결제|배송비|적립|쿠폰", name):
+                    continue
+                seen.add(no)
+                added += 1
+                img = re.search(r'src="(//[^"]+/web/product/(?:big|medium)[^"]+\.(?:jpg|png|gif))"', b)
+                image = ("https:" + img.group(1).split("?")[0]) if img else ""
+                cat = refine_cat(cat0, name)
+                sizes = kr_sizes(no) if (with_sizes and cat in ("mat", "sleeping_bag", "backpack", "tent")) else []
+                sizes = sizes or [""]
+                for sz in sizes:
+                    rows.append({
+                        "groupId": slugify(name),
+                        "category": cat,
+                        "company": "exped",
+                        "companyKorean": "엑스패드",
+                        "name": name,
+                        "nameKorean": name,
+                        "color": "",
+                        "colorKorean": "",
+                        "size": sz,
+                        "sizeKorean": sz,
+                        "weight": 0,
+                        "imageUrl": image,
+                        "specs": {},
+                        "_source": f"{KR}/product/detail.html?product_no={no}",
+                    })
+            if added == 0:
+                break
+            page += 1
+    return rows
+
+
+# ── (B) 국제 스펙 ──────────────────────────────────────────────────
+# KR 모델 음역 → EN slug 토큰
+MODEL_EN = {
+    "버사": "versa", "씸": "sim", "신매트": "synmat", "플렉스": "flex", "두라": "dura",
+    "울트라": "ultra", "테라": "terra", "컴포트": "comfort", "딥슬립": "deepsleep",
+    "메가매트": "megamat", "메가슬립": "megasleep", "럭스매트": "luxemat", "럭스울": "luxewool",
+    "멀티매트": "multimat", "더블매트": "doublemat", "드림워커": "dreamwalker", "루나": "luna",
+    "라이라": "lyra", "아우터": "outer", "스페이스": "space", "스카우트": "scout", "베놈": "venom",
+    "오거나이저": "organizer", "마운틴": "mountain", "프로": "pro", "블랙아이스": "black-ice",
+    "썬더": "thunder", "라이트닝": "lightning", "타이푼": "typhoon", "클라우드버스트": "cloudburst",
+    "슈노젤": "schnozzel", "필로우": "pillow", "심포니": "symphony", "컴팩트": "compact",
+    "미라": "mira", "게일": "gale", "카펠라": "capella", "베가": "vega", "오리온": "orion",
+    "sit": "sit", "패드": "pad", "블랭킷": "blanket", "퀼트": "quilt", "머미": "mummy",
+    "라이트": "lite", "맥스": "max", "오토": "auto", "듀오": "duo", "럭스": "luxe",
+    "듀라": "dura", "버사럭스": "versaluxe", "럭스울": "luxewool", "매트": "mat", "커버": "cover",
+    "블랙아이스": "blackice", "메가": "mega", "슬립": "sleep", "에어": "", "시트": "sit",
+    "제품": "", "이미지": "", "기능성": "", "캠핑": "", "베개": "", "exped": "",
+    "스페이스": "space", "익스트림": "extreme", "웨이스트": "waist", "벨트": "belt",
+    "비너스": "venus", "미라": "mira", "세레스": "ceres", "오리온": "orion", "카리나": "carina",
+    "게일": "gale", "베가": "vega", "카펠라": "capella", "안드로메다": "andromeda", "라이라": "lyra",
+    "텐트": "", "미니멀": "", "타프": "tarp", "폴": "pole", "이너": "inner", "메시": "mesh",
+    "hl": "hl", "xp": "xp", "ul": "ul", "필로우": "pillow", "심포니": "symphony", "머미": "mummy",
+    "토렌트": "torrent", "스카이라인": "skyline", "릿지라인": "ridgeline", "스냅샷": "snapshot",
+    "라이트닝": "lightning", "썬더": "thunder", "타이푼": "typhoon", "클라우드버스트": "cloudburst",
+    "임펄스": "impulse", "마운틴프로": "mountainpro", "블랙아이스": "blackice", "레이더": "radar",
+    "베놈": "venom", "웨이스트": "waist", "포켓": "pocket", "코드": "cord", "덕": "duck",
+}
+ROMAN = {"1": "i", "2": "ii", "3": "iii", "4": "iv", "5": "v", "6": "vi", "7": "vii", "8": "viii"}
+
+
+def to_roman(nk):
+    # 단독 정수(텐트 인용수)를 로마숫자로: "3"->"iii", "3xp"->"iiixp". R값/온도(2r,10c)는 유지.
+    return re.sub(r"\b(\d)(?![.rcfl\d])", lambda m: ROMAN.get(m.group(1), m.group(1)), nk)
+
+
+def num_key(name):
+    """이름의 숫자/온도/R값 → 정규화 토큰 (예: '1.5R'->'15r', '-10C 15F'->'10c15f', '5'->'5')."""
+    s = name.lower().replace("°", "")
+    s = re.sub(r"[-\s]", "", s)
+    toks = re.findall(r"\d+\.?\d*[rcfl]?", s)
+    return "".join(t.replace(".", "") for t in toks)
+
+
+def model_key(name):
+    """KR 이름 → EN 모델 토큰 문자열(음역)."""
+    toks = []
+    for w in re.split(r"[\s]+", name):
+        w2 = re.sub(r"[0-9.,\-°CFRL]", "", w).strip()
+        if not w2:
+            continue
+        toks.append(MODEL_EN.get(w2, w2.lower()))
+    return "".join(t for t in toks if t)
+
+
+def _spec_blocks(t):
+    """<h4>LABEL</h4><div>VALUE</div> → {label: value_text}. VALUE 의 <br> 는 공백/구분 유지."""
+    out = {}
+    for m in re.finditer(r"<h4[^>]*>([^<]+)</h4>\s*<div[^>]*>(.*?)</div>", t, re.S):
+        label = html.unescape(m.group(1)).strip()
+        val = re.sub(r"<br\s*/?>", " | ", m.group(2))
+        val = re.sub(r"\s+", " ", html.unescape(re.sub(r"<[^>]+>", " ", val))).strip()
+        if label and val and label not in out:
+            out[label] = val
+    return out
+
+
+def _parse_weight(val):
+    """'M: 1010 g | LW: 1415 g' → {'M':1010,'LW':1415}; '795 g' → {'':795}."""
+    res = {}
+    for part in val.split("|"):
+        part = part.strip()
+        ms = re.match(r"([A-Za-z0-9/+ ]+?)\s*:\s*([\d.,]+)\s*(kg|g)", part)
+        if ms:
+            v = float(ms.group(2).replace(",", ""))
+            res[ms.group(1).strip()] = round(v * 1000) if ms.group(3) == "kg" else round(v)
+        else:
+            mo = re.match(r"([\d.,]+)\s*(kg|g)", part)
+            if mo:
+                v = float(mo.group(1).replace(",", ""))
+                res[""] = round(v * 1000) if mo.group(2) == "kg" else round(v)
+    return res
+
+
+EN_CACHE = "out/exped-en-cache.json"
+
+
+def fetch_en_specs():
+    import os
+    if os.path.exists(EN_CACHE):
+        c = json.load(open(EN_CACHE))
+        return c["lookup"], c["urls"]
+    sm = curl(f"{EN}/sitemap.xml", follow=True)
+    urls = list(dict.fromkeys(re.findall(r"https://www\.exped\.com/en/products/[a-z0-9-]+/[a-z0-9-]+", sm)))
+    lookup = {}
+    for u in urls:
+        slug = u.rsplit("/", 1)[-1]
+        t = curl(u, follow=True)
+        blk = _spec_blocks(t)
+        sp = {}
+        # 무게: 패킹무게 우선 (텐트는 Max.Weight=패킹 / Min.Weight=최소). 매트/침낭은 'Weight'.
+        wl = {lab.lower(): v for lab, v in blk.items()
+              if lab.lower() in ("weight", "max. weight", "packed weight", "min. weight")}
+        for pref in ("max. weight", "packed weight", "weight", "min. weight"):
+            if pref in wl:
+                pw = _parse_weight(wl[pref])
+                if pw:
+                    sp["_weight"] = pw
+                    break
+        for lab, val in blk.items():
+            low = lab.lower()
+            if "person capacity" in low:
+                mc = re.search(r"\d+", val)
+                if mc:
+                    sp["capacity"] = int(mc.group(0))
+            elif "r-value" in low:
+                mr = re.search(r"[\d.]+", val)
+                if mr:
+                    sp["rValue"] = float(mr.group(0))
+            elif low == "temperature":
+                mt = re.search(r"-?[\d.]+", val)
+                if mt:
+                    sp["limitTemp"] = round(float(mt.group(0)))
+            elif low == "volume":
+                mv = re.search(r"[\d.]+", val)
+                if mv:
+                    sp["volume"] = int(float(mv.group(0)))
+            elif low == "thickness":
+                mth = re.search(r"[\d.]+", val)
+                if mth:
+                    sp["thickness"] = round(float(mth.group(0)) * 10)
+        key = re.sub(r"[^a-z]", "", slug) + num_key(slug)
+        lookup[key] = sp
+        lookup[re.sub(r"[-]", "", slug)] = sp
+    json.dump({"lookup": lookup, "urls": urls}, open(EN_CACHE, "w"), ensure_ascii=False)
+    return lookup, urls
+
+
+def apply_specs(rows, lookup):
+    filled = 0
+    for r in rows:
+        mk = model_key(r["nameKorean"])
+        mk_alpha = re.sub(r"[^a-z]", "", mk)
+        nk = num_key(r["nameKorean"])   # 사이즈(M/LW)는 제외 — 무게는 wmap[size] 로 별도 매칭
+        nk_r = to_roman(nk)             # 텐트 인용수 로마숫자 변형
+        cand = [mk + nk, mk_alpha + nk, mk + nk_r, mk_alpha + nk_r]
+        sp = None
+        for c in cand:
+            if c in lookup:
+                sp = lookup[c]
+                break
+        if not sp and mk_alpha and len(mk_alpha) >= 3:
+            # 느슨: 모델 prefix 일치 + 숫자(아라비아/로마) 포함
+            for k, v in lookup.items():
+                if k.startswith(mk_alpha[:4]) and (nk and nk in k or nk_r and nk_r in k):
+                    sp = v
+                    break
+        if not sp:
+            continue
+        wmap = sp.get("_weight") or {}
+        if wmap and not r["weight"]:
+            sz = r["size"]
+            if sz and sz in wmap:
+                r["weight"] = wmap[sz]
+            elif "" in wmap:
+                r["weight"] = wmap[""]
+            elif len(wmap) == 1:
+                r["weight"] = next(iter(wmap.values()))
+            else:
+                # 사이즈 라벨이 EN 과 안 맞으면(예: KR 'S-M-블랙' vs EN 'M/L'): 대표(최소) 무게
+                hit = None
+                if sz:
+                    for k, v in wmap.items():
+                        if k.lower() == sz.lower() or (k and sz.lower().startswith(k.lower())):
+                            hit = v
+                            break
+                r["weight"] = hit if hit else min(wmap.values())
+        extra = {k: v for k, v in sp.items() if not k.startswith("_")}
+        # 카테고리별 스펙 키 필터
+        if r["category"] == "mat":
+            r["specs"] = {**r["specs"], **{k: extra[k] for k in ("rValue", "thickness") if k in extra}}
+        elif r["category"] == "sleeping_bag":
+            r["specs"] = {**r["specs"], **{k: extra[k] for k in ("limitTemp",) if k in extra}}
+        elif r["category"] in ("backpack", "pouch"):
+            r["specs"] = {**r["specs"], **{k: extra[k] for k in ("volume",) if k in extra}}
+        elif r["category"] in ("tent", "tent_acc"):
+            r["specs"] = {**r["specs"], **{k: extra[k] for k in ("capacity",) if k in extra}}
+        filled += 1
+    return filled
+
+
+def main():
+    out_path = sys.argv[1] if len(sys.argv) > 1 else "out/exped-FINAL.json"
+    from collections import Counter
+    kr = crawl_kr()
+    print(f"KR rows: {len(kr)} (제품 {len(set(r['groupId'] for r in kr))})")
+    lookup, en_urls = fetch_en_specs()
+    print(f"EN 제품 스펙: {len(en_urls)}개")
+    filled = apply_specs(kr, lookup)
+    json.dump(kr, open(out_path, "w"), ensure_ascii=False, indent=2)
+    print(f"스펙 매칭된 행: {filled}")
+    print("by category:", dict(Counter(r["category"] for r in kr)))
+    print("weight>0:", sum(1 for r in kr if r["weight"]), "/", len(kr))
+    print(f"-> {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/crawl-gear/sites/exped.js
+++ b/.claude/skills/crawl-gear/sites/exped.js
@@ -1,0 +1,10 @@
+// 엑스패드 — 2소스 하이브리드. 실제 크롤은 standalone `exped.py`.
+//   (A) exped.co.kr (Cafe24): 전 제품(한글명·사이즈옵션·이미지). 무게는 이미지에만.
+//   (B) www.exped.com/en: 제품 페이지 h4/div 스펙(Weight/Max.Weight/R-Value/Temperature) → 음역+숫자 매칭.
+//   크롤:    python3 exped.py out/exped-FINAL.json
+//   미리보기: node crawl.js exped --from-json=out/exped-FINAL.json
+export default {
+  name: 'exped', company: 'exped', companyKorean: '엑스패드',
+  baseUrl: 'https://exped.co.kr', defaultCategories: [],
+  crawl: async () => { throw new Error('exped.py 로 크롤하세요'); },
+};


### PR DESCRIPTION
## 요약
엑스패드(Exped) 제품 카탈로그를 크롤링해 Firestore에 적재했습니다. (335개 / inserted 333, updated 2)

## 작업 내용
- **exped.py** — KR(exped.co.kr) 8개 카테고리 크롤 + EN(exped.com) 스펙 무게 매칭
  - 음역 매칭(한글 모델명 → 영문 토큰/숫자), 텐트 로마숫자 매칭, 텐트는 패킹(최대)무게 우선
- **exped-color-ocr.py** — 색상 없는 제품의 상세이미지 OCR("색상 : ● 메로우")로 색상 보강
- **exped-weight-ocr.py** — 매트/침낭/텐트 무게를 상세 표 OCR로 추출 (표 5형식 지원)
  - 행형 / 매트헤더형 / 컬럼형(사이즈 가로·무게 세로) / 단일사이즈 / 텐트 라벨형(최대무게)
  - SIZE_HEAD 정규식 교대 순서 버그 수정(MW가 M+W로 쪼개지던 문제)
- **brands/exped.md** — 사이트 링크·크롤 주의사항 메모

## 무게 커버리지: 260/335
- 매트 138/138 (100%)
- 침낭 33/33 (100%)
- 텐트 31/33 (94%)

## 필드 일관성
- color=영문 / colorKorean=한글, size=영문코드 / sizeKorean=한글
- 사이즈는 제품명 끝에 부착(변형 처리 룰)

🤖 Generated with [Claude Code](https://claude.com/claude-code)