### PR TITLE
웨스턴마운티니어링(Western Mountaineering) 크롤 어댑터

### DIFF
--- a/.claude/skills/crawl-gear/brands/western-mountaineering.md
+++ b/.claude/skills/crawl-gear/brands/western-mountaineering.md
@@ -1,0 +1,33 @@
+# 웨스턴마운티니어링 (western-mountaineering)
+
+- **공식**: https://www.westernmountaineering.com  (WooCommerce, 미국 프리미엄 구스다운 침낭 전문)
+- 크롤러: `wm.py` (WooCommerce product-attributes 표 파싱), 미리보기 스텁 `sites/wm.js`
+- companyKorean: 웨스턴마운티니어링 · 마지막 크롤: 2026-07, 206행(제품 72). 무게 186/206.
+
+## ⚠️ 주의사항
+
+### 크롤 & 구조
+1. **전체 제품 = WP 사이트맵** `wp-sitemap-posts-product-1.xml` (72개, 품절 포함). 카테고리 리스팅은
+   페이지네이션(5p)·중복 많음. `product-sitemap.xml` 은 404 → WP 코어 사이트맵 사용.
+2. **서버렌더(WooCommerce)** → curl + UA 직접. 상세 스펙은 `woocommerce-product-attributes` 표(label/value).
+   길이별 값은 **nested `insidetable`** → 아이템 행 단위로 분할 파싱해야 안쪽 `</td>` 에 안 걸린다.
+3. **사이트가 미터법을 서빙**: Total Weight `820 g`, Temp Rating `-7°C`, 사이즈 `165cm`. 단 **혼재**하니
+   (`980`=단위없는 grams, `2128 g`, 임페리얼 `1 lb 13 oz`, oz) `_to_g` 가 그램병기/평문/oz·lb 모두 처리.
+   온도도 °C/°F 양쪽. **미터법 우선, 반올림은 oz/lb 변환 때만**.
+
+### 카테고리 & 변형
+4. **침낭 이름에 'bag' 이 없다**(Antelope·Puma·Kodiak·AlpinLite…) → **스펙 기반 분류**:
+   `Temp Rating`/`Shape` 있으면 sleeping_bag. 슬러그 접미 `-mf/-gws/-stormshield`, quilt/comforter/underquilt 도 침낭.
+   부티→etc, 재킷/파카/베스트/팬츠→clothing, 스터프색/스토리지색→pouch, 라이너/VBL/커플러/익스팬더→etc.
+5. **mf/gws/stormshield 는 원단 라인**(같은 모델의 다른 셸) → 별도 제품(이름·groupId 구분됨).
+6. **변형**: 침낭=길이(Total Weight 표의 키), **지퍼 L/R 은 무게 무관 → 접음**(Total Weight 표만 쓰면 자동 접힘).
+   의류=사이즈(variations `attribute_pa_size_garments` xs/sm/md/lg/lg, 또는 full word small/medium/large).
+7. **이미지는 og:image 가 없다** → `data-large_image`(WooCommerce 갤러리 풀사이즈) 사용.
+
+### 스펙 & 한글화
+8. 침낭 스펙: Shape, Fill(850+ Goose Down→fillMaterial/fillPower), Temp Rating(→limitTemp),
+   Total Weight(→weight, 길이별), Fill Weight(→fillWeight, 길이별). **fillWeight 는 침낭 스키마에만** 넣을 것.
+9. 의류: Avg. Total Weight(단일, 그램병기), Shell Fabric(→material), 이름으로 type(jacket/vest/pants)·hasHood.
+10. **한글화 = 음역**(KR 공식 수입사명 미확인). `NAME_KO` 모델·구조어 사전으로 nameKorean 생성
+    (알핀라이트/앤털로프/스톰실드/컴포터…), 미등재 코드(MF/GWS/XR/VBL)는 유지. sizeKorean: 침낭 cm 유지,
+    의류 S/M/L→스몰/미디엄/라지. colorKorean 사전 음역.

--- a/.claude/skills/crawl-gear/sites/wm.js
+++ b/.claude/skills/crawl-gear/sites/wm.js
@@ -1,0 +1,9 @@
+// 웨스턴마운티니어링(Western Mountaineering) — WooCommerce(www.westernmountaineering.com).
+// 실제 크롤은 standalone `wm.py`. 침낭 무게/온도/충전, 의류 사이즈까지 WooCommerce attributes 표에서 파싱.
+//   크롤:    python3 wm.py out/wm-FINAL.json
+//   미리보기: node crawl.js wm --from-json=out/wm-FINAL.json
+export default {
+  name: 'wm', company: 'western-mountaineering', companyKorean: '웨스턴마운티니어링',
+  baseUrl: 'https://www.westernmountaineering.com', defaultCategories: [],
+  crawl: async () => { throw new Error('wm.py 로 크롤하세요'); },
+};

--- a/.claude/skills/crawl-gear/wm.py
+++ b/.claude/skills/crawl-gear/wm.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+# 웨스턴마운티니어링(Western Mountaineering) 크롤 — WooCommerce(www.westernmountaineering.com).
+#  - 전체 제품: wp-sitemap-posts-product-1.xml. 상세는 서버렌더라 curl 직접.
+#  - 스펙: WooCommerce 'product-attributes' 표(label/value). 길이별 값은 nested insidetable.
+#    침낭: Temp Rating(°F), Total Weight(길이별 'N lb M oz'), Fill Weight(길이별), Fill(850+ down), Shape, Color.
+#    의류: Avg. Total Weight '6.5 oz (185g)'(그램 병기), Shell Fabric, Fill, 사이즈 XS~XL.
+#  - 변형: 침낭=길이(지퍼 L/R 은 무게무관→접음), 의류=사이즈. 무게 lb/oz→g 변환.
+# 사용: python3 wm.py out/wm-FINAL.json
+import html
+import json
+import re
+import subprocess
+import sys
+import time
+
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+BASE = "https://www.westernmountaineering.com"
+SITEMAP = f"{BASE}/wp-sitemap-posts-product-1.xml"
+
+FEET_CM = {"5'0\"": "150cm", "5'6\"": "165cm", "6'0\"": "180cm", "6'6\"": "200cm", "7'0\"": "215cm"}
+COLOR_KOR = {
+    "black": "블랙", "cranberry": "크랜베리", "navy": "네이비", "blue": "블루", "red": "레드",
+    "green": "그린", "charcoal": "차콜", "grey": "그레이", "gray": "그레이", "tan": "탄",
+    "olive": "올리브", "orange": "오렌지", "gold": "골드", "royal": "로열", "forest": "포레스트",
+    "smoke": "스모크", "slate": "슬레이트", "burgundy": "버건디", "teal": "틸", "white": "화이트",
+    "clay": "클레이", "copper": "코퍼", "crimson": "크림슨", "lime": "라임", "magma": "마그마",
+    "mesh": "메쉬", "moss": "모스", "neon": "네온", "platinum": "플래티넘", "plum": "플럼",
+    "sage": "세이지", "sand": "샌드", "silver": "실버", "sky": "스카이", "stone": "스톤",
+    "turquoise": "터쿼이즈", "yellow": "옐로",
+}
+
+# 제품명 음역(KR 공식 수입사 표기 미확인 → 음역 생성). 모델 고유명 + 구조어. 미등재 단어는 영문 유지.
+NAME_KO = {
+    "alder": "앨더", "alpinlite": "알핀라이트", "antelope": "앤털로프", "apache": "아파치",
+    "astralite": "아스트라라이트", "badger": "배저", "bison": "바이슨", "bristlecone": "브리슬콘",
+    "caribou": "카리부", "cloudlite": "클라우드라이트", "cypress": "사이프러스", "dreamlite": "드림라이트",
+    "everlite": "에버라이트", "flylite": "플라이라이트", "highlite": "하이라이트", "kodiak": "코디악",
+    "lynx": "링스", "megalite": "메가라이트", "mitylite": "마이티라이트", "monolite": "모노라이트",
+    "nanolite": "나노라이트", "ponderosa": "폰데로사", "puma": "퓨마", "sequoia": "세쿼이아",
+    "summerlite": "서머라이트", "sycamore": "시카모어", "terralite": "테라라이트", "ultralite": "울트라라이트",
+    "versalite": "버사라이트", "slinglite": "슬링라이트", "flash": "플래시", "flight": "플라이트",
+    "ion": "이온", "meltdown": "멜트다운", "vapor": "베이퍼", "quickflash": "퀵플래시", "snojack": "스노잭",
+    "hotsac": "핫색", "cloudrest": "클라우드레스트", "sonora": "소노라", "tioga": "티오가", "cloud": "클라우드",
+    # 구조어
+    "stormshield": "스톰실드", "comforter": "컴포터", "quilt": "퀼트", "top": "탑", "underquilt": "언더퀼트",
+    "jacket": "재킷", "parka": "파카", "vest": "베스트", "pants": "팬츠", "hoody": "후디", "hooded": "후디드",
+    "booties": "부티", "down": "다운", "pillows": "필로우", "pillow": "필로우", "liner": "라이너",
+    "liners": "라이너", "sleeping": "슬리핑", "sleep": "슬립", "bag": "백", "expander": "익스팬더",
+    "coupler": "커플러", "summer": "서머", "stuff": "스터프", "sack": "색", "storage": "스토리지",
+    "overfill": "오버필", "expedition": "엑스페디션", "standard": "스탠다드", "hat": "모자", "shirt": "셔츠",
+    "long": "롱", "sleeve": "슬리브", "t-shirts": "티셔츠", "tee": "티", "western": "웨스턴",
+    "mountaineering": "마운티니어링", "logo": "로고", "weather": "웨더", "proof": "프루프", "winter": "윈터",
+    "all": "올",
+}
+SIZE_KO = {"XS": "엑스스몰", "S": "스몰", "M": "미디엄", "L": "라지", "XL": "엑스라지",
+           "XXL": "더블엑스라지", "XXXL": "트리플엑스라지"}
+
+
+def kor_name(name):
+    """영문 제품명 → 음역. MF/GWS/XR/VBL 등 코드·숫자는 유지."""
+    out = []
+    for w in name.split():
+        key = re.sub(r"[^a-z0-9-]", "", w.lower())
+        out.append(NAME_KO.get(key, w))
+    return " ".join(out)
+
+
+def curl(url):
+    time.sleep(0.05)
+    for _ in range(3):
+        out = subprocess.run(["curl", "-sS", "-m", "30", "-A", UA, url], capture_output=True, timeout=35)
+        if out.returncode == 0:
+            return out.stdout.decode("utf-8", "replace")
+        time.sleep(1)
+    return ""
+
+
+def color_kor(en):
+    if not en:
+        return ""
+    return "/".join(" ".join(COLOR_KOR.get(w.lower(), w) for w in part.split())
+                     for part in re.split(r"\s*/\s*", en))
+
+
+def slugify(name):
+    return "western-mountaineering_" + re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+
+
+def classify(name, slug, attrs):
+    # WM 침낭 이름엔 'bag' 이 없다(Antelope/Puma/Kodiak…) → 스펙(Temp Rating/Shape)·슬러그 접미로 판별.
+    n = (name + " " + slug).lower()
+    if re.search(r"boot", n):
+        return "etc"
+    if re.search(r"pillow", n):
+        return "pillow"
+    if re.search(r"jacket|parka|vest|pants|hoody|shirt|tee|t-shirt|\bhat\b|\bcap\b", n):
+        return "clothing"
+    if ("Temp Rating" in attrs or "Temperature Rating" in attrs or "Shape" in attrs
+            or re.search(r"-(?:mf|gws|stormshield)\b|quilt|comforter|underquilt", n)):
+        return "sleeping_bag"
+    if re.search(r"stuff.sack|storage.sack", n):
+        return "pouch"
+    return "etc"  # 라이너/VBL/커플러/익스팬더/오버필 등
+
+
+def _to_g(s):
+    """'820 g' / '1 lb 13 oz' / '17 oz' / '6.5 oz (185g)' → grams(int). 미터법 병기/평문 우선."""
+    mg = re.search(r"\((\d+)\s*g\)", s) or re.search(r"(?<![a-zA-Z])(\d+)\s*g\b", s)  # 그램(병기/평문) 우선
+    if mg:
+        return int(mg.group(1))
+    lb = re.search(r"([\d.]+)\s*lb", s)
+    oz = re.search(r"([\d.]+)\s*oz", s)
+    g = 0.0
+    if lb:
+        g += float(lb.group(1)) * 453.592
+    if oz:
+        g += float(oz.group(1)) * 28.3495
+    if g:
+        return round(g)
+    mb = re.fullmatch(r"\s*(\d+)\s*", s)  # 단위 없는 맨숫자(미터법 표에선 grams)
+    if mb and 5 <= int(mb.group(1)) <= 8000:
+        return int(mb.group(1))
+    return 0
+
+
+def _clean(s):
+    return re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", html.unescape(s))).strip()
+
+
+def parse_attrs(t):
+    """WooCommerce product-attributes 표 → {label: value}. value 는 문자열 또는 {길이: 값}.
+    아이템 행 단위로 분할해야 nested insidetable(길이별 값)의 안쪽 </td> 에 안 걸린다."""
+    attrs = {}
+    for ch in re.split(r'<tr class="woocommerce-product-attributes-item[^"]*">', t)[1:]:
+        ml = re.search(r'__label">(.*?)</td>', ch, re.S)
+        mv = re.search(r'__value">(.*)', ch, re.S)
+        if not (ml and mv):
+            continue
+        label = _clean(ml.group(1))
+        vh = mv.group(1)
+        if not label:
+            continue
+        if "insidetable" in vh:  # 길이별 nested table
+            nested = vh.split("</table>")[0]
+            sub = {}
+            for k, v in re.findall(r"<td[^>]*>(.*?)</td>\s*<td[^>]*>(.*?)</td>", nested, re.S):
+                kk, vv = _clean(k), _clean(v)
+                if kk:
+                    sub[kk] = vv
+            if sub:
+                attrs[label] = sub
+                continue
+        pv = re.match(r"(.*?)</td>", vh, re.S)  # 단일값: 첫 </td> 까지
+        attrs[label] = _clean(pv.group(1) if pv else vh)
+    return attrs
+
+
+def build_specs(cat, attrs, name):
+    specs = {}
+    fill = attrs.get("Fill", "") if isinstance(attrs.get("Fill"), str) else ""
+    if cat == "sleeping_bag":
+        sh = attrs.get("Shape")
+        if isinstance(sh, str) and sh:
+            specs["shape"] = sh
+        if re.search(r"down|goose|duck", fill, re.I):
+            specs["fillMaterial"] = "down"
+        mp = re.search(r"(\d{3})\+?\s*(?:power|fill)", fill, re.I)
+        if mp:
+            specs["fillPower"] = int(mp.group(1))
+        tr = attrs.get("Temp Rating") or attrs.get("Temperature Rating")
+        if isinstance(tr, str):
+            mc = re.search(r"(-?\d+)\s*°?\s*C\b", tr)  # 미터법(°C) 우선
+            mf = re.search(r"(-?\d+)\s*°?\s*F\b", tr)
+            if mc:
+                specs["limitTemp"] = int(mc.group(1))
+            elif mf:
+                specs["limitTemp"] = round((int(mf.group(1)) - 32) * 5 / 9)
+    elif cat == "clothing":
+        if re.search(r"down|goose|duck", fill, re.I):
+            specs["fillMaterial"] = "down"
+        sf = attrs.get("Shell Fabric") or attrs.get("Fabric")
+        if isinstance(sf, str) and sf:
+            specs["material"] = sf
+        if re.search(r"jacket|parka", name, re.I):
+            specs["type"] = "jacket"
+        elif re.search(r"vest", name, re.I):
+            specs["type"] = "vest"
+        elif re.search(r"pants", name, re.I):
+            specs["type"] = "pants"
+        if re.search(r"hood", name, re.I):
+            specs["hasHood"] = True
+    return specs
+
+
+SIZE_MAP = {"xs": "XS", "sm": "S", "s": "S", "md": "M", "m": "M", "lg": "L", "l": "L",
+            "xl": "XL", "xxl": "XXL", "xxxl": "XXXL",
+            "xsmall": "XS", "small": "S", "medium": "M", "large": "L", "xlarge": "XL", "xxlarge": "XXL"}
+
+
+def garment_variants(t):
+    """의류 variations 에서 (사이즈 목록, 대표 색상) 추출."""
+    m = re.search(r'data-product_variations="([^"]+)"', t)
+    if not m:
+        return [], ""
+    try:
+        vs = json.loads(html.unescape(m.group(1)))
+    except Exception:
+        return [], ""
+    sizes, colors = [], []
+    for v in vs:
+        a = v.get("attributes", {})
+        for k, val in a.items():
+            if "size" in k and val:
+                sz = SIZE_MAP.get(val.lower(), val.upper())
+                if sz not in sizes:
+                    sizes.append(sz)
+            if "color" in k and val:
+                colors.append(val)
+    color = ""
+    if colors:
+        color = "/".join(w.capitalize() for w in colors[0].split("-"))
+    return sizes, color
+
+
+def crawl():
+    slugs = sorted(set(re.findall(r"/product/([a-z0-9-]+)/", curl(SITEMAP))))
+    print(f"제품 {len(slugs)}개", flush=True)
+    rows = []
+    for i, slug in enumerate(slugs, 1):
+        t = curl(f"{BASE}/product/{slug}/")
+        mn = re.search(r'product_title[^>]*>([^<]+)</h1>', t)
+        name = html.unescape(mn.group(1)).strip() if mn else slug
+        attrs = parse_attrs(t)
+        cat = classify(name, slug, attrs)
+        # 이미지: WooCommerce 갤러리 data-large_image(풀사이즈) → wp-post-image src. og:image 없음.
+        mi = re.search(r'data-large_image="([^"]+)"', t) or re.search(r'wp-post-image[^>]*?\bsrc="([^"]+)"', t)
+        image = html.unescape(mi.group(1)).split("?")[0] if mi else ""
+        # 색상
+        color = attrs.get("Color", "") if isinstance(attrs.get("Color"), str) else ""
+        # 무게(길이별 또는 단일)
+        tw = attrs.get("Total Weight") or attrs.get("Avg. Total Weight") or attrs.get("Weight")
+        fw = attrs.get("Fill Weight") or attrs.get("Avg. Fill Weight")
+        specs0 = build_specs(cat, attrs, name)
+        gid = slugify(name)
+
+        name_ko = kor_name(name)
+
+        def emit(size_en, size_ko, weight, fill_g):
+            sp = dict(specs0)
+            if fill_g and cat == "sleeping_bag":  # fillWeight 는 침낭 스키마에만 있음
+                sp["fillWeight"] = fill_g
+            nm = f"{name} {size_en}".strip() if size_en else name
+            nm_ko = f"{name_ko} {size_ko}".strip() if size_ko else name_ko
+            rows.append({
+                "groupId": gid, "category": cat, "company": "western-mountaineering",
+                "companyKorean": "웨스턴마운티니어링", "name": nm, "nameKorean": nm_ko,
+                "color": color, "colorKorean": color_kor(color),
+                "size": size_en, "sizeKorean": size_ko, "weight": weight,
+                "imageUrl": image, "specs": sp,
+                "_source": f"{BASE}/product/{slug}/",
+            })
+
+        if isinstance(tw, dict):  # 침낭: 길이별
+            for length, wstr in tw.items():
+                w = _to_g(wstr)
+                fill_g = _to_g(fw[length]) if isinstance(fw, dict) and length in fw else (_to_g(fw) if isinstance(fw, str) else 0)
+                size_ko = FEET_CM.get(length, length)
+                emit(length, size_ko, w, fill_g)
+        elif cat == "clothing":  # 의류: 사이즈별(무게는 단일 평균)
+            w = _to_g(tw) if isinstance(tw, str) else 0
+            fill_g = _to_g(fw) if isinstance(fw, str) else 0
+            sizes, vcolor = garment_variants(t)
+            if not color and vcolor:
+                color = vcolor
+            for sz in (sizes or [""]):
+                emit(sz, SIZE_KO.get(sz, sz), w, fill_g)
+        else:  # 단일(액세서리)
+            w = _to_g(tw) if isinstance(tw, str) else 0
+            fill_g = _to_g(fw) if isinstance(fw, str) else 0
+            emit("", "", w, fill_g)
+        if i % 10 == 0 or i == len(slugs):
+            print(f"  {i}/{len(slugs)} (rows {len(rows)})", flush=True)
+    return rows
+
+
+def main():
+    out = sys.argv[1] if len(sys.argv) > 1 else "out/wm-FINAL.json"
+    rows = crawl()
+    json.dump(rows, open(out, "w"), ensure_ascii=False, indent=2)
+    print(f"완료: {len(rows)}행 -> {out}", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 요약
웨스턴마운티니어링(WooCommerce) 제품 카탈로그를 크롤링해 Firestore에 적재했습니다. (206행 / inserted 206, failed 0)

## 작업 내용
- **wm.py** — WooCommerce 크롤러
  - 전체 제품 = WP 사이트맵(72개, 품절 포함). 상세는 `woocommerce-product-attributes` 표
  - 길이별 값은 **nested insidetable** → 아이템 행 단위 분할 파싱
  - **미터법/임페리얼 혼재 대응**: `820 g`/`980`(단위없는 grams)/`1 lb 13 oz`/oz, 온도 °C·°F
- **침낭 분류** — 이름에 'bag'이 없어(Antelope/Puma/Kodiak) Temp Rating/Shape 스펙 기반. mf/gws/stormshield 원단 라인은 별도 제품
- **변형** — 침낭=길이(지퍼 L/R은 무게 무관→접음), 의류=사이즈 XS~XL
- **스펙** — 침낭: shape·fillMaterial·fillPower·limitTemp·fillWeight / 의류: material·type·hasHood
- **이미지** — og:image 없어 `data-large_image` 사용
- **한글화 음역** — nameKorean(알핀라이트·앤털로프 스톰실드)·sizeKorean(스몰/미디엄)·colorKorean

## 커버리지
- 침낭 122행(무게 121·온도 121·충전력 120·충전량 121) · 의류 72 · 기타 12
- 무게 186/206 (미커버는 Cloud 9 컴포터·액세서리 무게 부재)

🤖 Generated with [Claude Code](https://claude.com/claude-code)