### PR TITLE
꼴로르(CCOLORE) 크롤 어댑터 + 색상 필드언어 룰 보강

### DIFF
--- a/.claude/skills/crawl-gear/SKILL.md
+++ b/.claude/skills/crawl-gear/SKILL.md
@@ -264,6 +264,7 @@ import('puppeteer').then(async ({default: p}) => {
 - [ ] 같은 제품의 다른 색상이 같은 `groupId`인가?
 - [ ] spec 필드가 schema 키와 일치하는가? (오타 없음)
 - [ ] empty 값이 `""` (null/undefined 아님)?
+- [ ] **`color`(영문)에 한글이 없는가? `colorKorean`(한글)에 영문이 없는가?** (KR 사이트가 색상을 한글로만 표기하면 색상 사전으로 `color`를 영문 변환할 것 — `color`에 한글이 들어가면 안 됨. `name`/`sizeKorean`도 동일: `name`·`size`=영문, `nameKorean`·`sizeKorean`=한글.)
 
 ### 어댑터 코드 컨벤션
 

--- a/.claude/skills/crawl-gear/brands/ccolore.md
+++ b/.claude/skills/crawl-gear/brands/ccolore.md
@@ -1,0 +1,37 @@
+# 꼴로르 (ccolore)
+
+- **공식**: https://ccolore.com  (Cafe24, 한국 초경량 다운 침낭/퀼트 + 실타프·텐트·다운의류)
+- 크롤러: `ccolore.py`, 무게 OCR 폴백 `ccolore-weight-ocr.py`, 미리보기 스텁 `sites/ccolore.js`
+- companyKorean: 꼴로르 · 마지막 크롤: 2026-07, 77행(제품 47). 무게 61/77.
+
+## ⚠️ 주의사항
+
+### 크롤 & 카테고리
+1. **Cafe24 (구형 cate_no)** — 상품은 `/product/list.html?cate_no=89`(Shop). `/category/.../N/` 아님.
+   전 상품은 89를 페이지네이션(7p). curl+UA 직접. 카드 `anchorBoxId_<no>`, 이름 `og:title`(한글).
+2. **색상 = 이름 말미 ' - 솔트 그레이'**(CAYL식). 각 색상이 별도 product_no. 수량(2ea)·코드는 색상 아님(제외).
+3. **옵션이 애드온으로 오염** — 타프 폴·펙(8ea)·세트 옵션이 사이즈로 섞임 → **진짜 사이즈(S/M/L/XL) 옵션만
+   확장**(REAL_SIZE 화이트리스트). 타프/텐트의 실제 사이즈는 제품명에 있음(실타프 헥사 L). 안 그러면 행 폭발.
+4. 분류: 에어라이트/얼티밋라이트/썸머라이트/슬립스퀘어/다운라이너→sleeping_bag, 실타프→tarp, 텐트→tent,
+   사이드월→tent_acc, 다운자켓/머플러/양말→clothing, 압축색/메쉬망/파우치→pouch, 폴/스트링/스토퍼→etc.
+
+### 스펙 (침낭)
+5. **측정표(사이즈별 컬럼)**: `Full Weight | 529 | 548 | (g)`(제품무게), `Fill Weight | 290 | 300 | (g)`(충전량).
+   사이즈 헤더 M/L 순서로 매핑. 이너사이즈 괄호값(205(187))은 무시.
+6. **온도** `2℃ / -3℃ / -15℃` → comfortTemp=2, limitTemp=-3(익스트림 -15 버림). **필파워** `필파워 : 1000 CU.IN`(3~4자리!).
+   충전재 구스/덕 → fillMaterial=down. **무게 소수점 유지**.
+
+### 무게 형식 4종 (`parse_weights`)
+7. 컬럼표(529/548) · 단일 콤마(`Full Weight|2,390g`) · 인라인 사이즈별(`S - 335g, M - 351g`, 다운자켓) ·
+   총 무게 kg(`총 무게 2.8kg`, 텐트).
+
+### 무게 OCR 폴백 (`ccolore-weight-ocr.py`)
+8. **CL/CT 실타프·사이드월(콜라보/코팅 라인)은 무게가 텍스트 없이 이미지에만** 있음
+   (`/web/upload/NNEditor/` 스펙표 `Full Weight 1,680g(Skin), 770g(Acc)`). macOS Vision OCR 로 추출,
+   **스킨(본체) 무게 우선**. 하드웨어(폴·스트링·케이스·양말·V팩)는 무게 없어 스킵.
+   ⚠️ 크롤러 재실행하면 OCR 무게가 초기화되므로 **재크롤 후엔 OCR 폴백을 다시 돌려야 함**.
+
+### 필드 언어
+9. **color=영문, colorKorean=한글.** 사이트가 색상을 한글로만 표기 → `KO_COLOR_EN` 사전으로 color 를 영문 변환
+   (솔트 그레이 → Salt Grey). name/size=영문(사이즈 M), nameKorean/sizeKorean=한글(미디엄).
+   (순수 한국 브랜드라 제품명 자체는 한글 verbatim.)

--- a/.claude/skills/crawl-gear/ccolore-weight-ocr.py
+++ b/.claude/skills/crawl-gear/ccolore-weight-ocr.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# 꼴로르 무게 OCR — 텍스트에 무게 없는 제품(CL/CT 실타프·사이드월 등, 콜라보/코팅 라인)의 무게가
+# 상세 이미지(/web/upload/NNEditor/) 스펙 표에 'Full Weight 1,680g(Skin), 770g(Acc)' 형태로 있음.
+# macOS Vision OCR 로 추출. 스킨(본체) 무게 우선. 대상: weight==0 이고 하드웨어 아님.
+# 사용: python3 ccolore-weight-ocr.py out/ccolore-FINAL.json
+import io
+import json
+import re
+import subprocess
+import sys
+
+from PIL import Image
+
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+# 무게가 아예 없는 하드웨어/소모품은 OCR 스킵
+SKIP = re.compile(r"폴대|폴\b|pole|스트링|스토퍼|코드락|카라비너|스테이크|펙|케이스|case|캘린더|커버|양말|socks|스트랩", re.I)
+
+
+def cb(u, ref="https://ccolore.com/"):
+    try:
+        return subprocess.run(["curl", "-sS", "-m", "25", "-A", UA, "-e", ref, u],
+                              capture_output=True, timeout=30).stdout
+    except Exception:
+        return b""
+
+
+def ocr_text(product_no):
+    t = cb(f"https://ccolore.com/product/detail.html?product_no={product_no}").decode("utf-8", "replace")
+    imgs = [u for u in dict.fromkeys(re.findall(r'/web/upload/NNEditor/[^"\']+\.(?:jpg|jpeg|png)', t))]
+    out = []
+    for p in imgs:
+        raw = cb("https://ccolore.com" + p)
+        if raw[:3] != b"\xff\xd8\xff" and raw[:4] != b"\x89PNG":
+            continue
+        try:
+            im = Image.open(io.BytesIO(raw)).convert("RGB")
+        except Exception:
+            continue
+        W, H = im.size
+        for top in range(0, H, 1400):
+            im.crop((0, top, W, min(top + 1500, H))).save("/tmp/_ccw.jpg")
+            try:
+                items = json.loads(subprocess.run(["python3", "ocr.py", "/tmp/_ccw.jpg"],
+                                                  capture_output=True, timeout=60).stdout.decode("utf-8", "replace"))
+            except Exception:
+                continue
+            out.append(" ".join(i["t"] for i in items))
+    return " ".join(out)
+
+
+def parse_weight(txt):
+    """'Full Weight 1,680g(Skin), 770g(Acc)' → 1680(스킨). 'Full Weight 2,390g' → 2390."""
+    # 스킨(본체) 우선
+    m = re.search(r"([\d,]+)\s*g\s*\(\s*Skin\s*\)", txt, re.I)
+    if m:
+        return float(m.group(1).replace(",", ""))
+    # 'Full Weight' 근처 g 값(OCR 오타 Fulll 허용). 라벨 앞/뒤 40자 내 첫 g 값.
+    for lm in re.finditer(r"[Ff]ul+\s*[Ww]eight", txt):
+        window = txt[max(0, lm.start() - 45):lm.end() + 45]
+        gs = [float(x.replace(",", "")) for x in re.findall(r"([\d,]+(?:\.\d+)?)\s*g\b", window)
+              if 30 <= float(x.replace(",", "")) <= 8000 and "Acc" not in window[window.find(x):window.find(x) + 20]]
+        if gs:
+            return gs[0]
+    return 0
+
+
+def main():
+    path = sys.argv[1]
+    rows = json.load(open(path))
+    by_no = {}
+    for r in rows:
+        if not r["weight"] and not SKIP.search(r["name"]):
+            no = re.search(r"product_no=(\d+)", r["_source"]).group(1)
+            by_no.setdefault(no, []).append(r)
+    print(f"무게 없는 대상(하드웨어 제외) product_no: {len(by_no)}", flush=True)
+    filled = 0
+    for i, (no, rs) in enumerate(by_no.items(), 1):
+        w = parse_weight(ocr_text(no))
+        if w:
+            for r in rs:
+                r["weight"] = w
+            filled += 1
+        if i % 5 == 0 or i == len(by_no):
+            print(f"  {i}/{len(by_no)} (채움 {filled})", flush=True)
+    json.dump(rows, open(path, "w"), ensure_ascii=False, indent=2)
+    print(f"완료: {filled} 제품 무게 채움 -> {path}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/crawl-gear/ccolore.py
+++ b/.claude/skills/crawl-gear/ccolore.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+# 꼴로르(CCOLORE) 크롤 — Cafe24 한국공식(ccolore.com). 초경량 다운 침낭/퀼트 + 실타프·텐트·의류.
+#  - 제품명 한글, 색상은 이름 말미 ' - 솔트 그레이'(CAYL식). 사이즈 M/L 옵션.
+#  - 침낭 스펙: 측정표(사이즈별 Full Weight=제품무게, Fill Weight=충전량) + 온도 'N℃/N℃/N℃'(컴포트/리밋/익스트림)
+#    + 필파워(N CU.IN) + 충전재(구스/덕 다운).
+# 사용: python3 ccolore.py out/ccolore-FINAL.json
+import html
+import json
+import re
+import subprocess
+import sys
+import time
+
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+BASE = "https://ccolore.com"
+CATE = 89  # Shop
+
+# 색상: 사이트가 한글로만 표기 → color 필드(영문)용 한글→영문 사전. colorKorean 은 원본 한글.
+KO_COLOR_EN = {
+    "그레이": "Grey", "그린": "Green", "딥그린": "Deep Green", "레드": "Red", "브라운": "Brown",
+    "블랙": "Black", "블루": "Blue", "빈티지": "Vintage", "샌드": "Sand", "세이지": "Sage",
+    "솔트": "Salt", "애쉬": "Ash", "올리브": "Olive", "올리브그린": "Olive Green", "카키": "Khaki",
+    "포레스트": "Forest", "화이트": "White", "아이보리": "Ivory", "베이지": "Beige", "차콜": "Charcoal",
+    "네이비": "Navy", "힙포": "Hippo",
+}
+SIZE_KO = {"S": "스몰", "M": "미디엄", "L": "라지", "XL": "엑스라지", "XS": "엑스스몰",
+           "XXL": "더블엑스라지", "XXS": "더블엑스스몰", "XXXL": "트리플엑스라지",
+           "FREE": "프리", "REGULAR": "레귤러", "LONG": "롱", "WIDE": "와이드"}
+
+
+def curl(url):
+    time.sleep(0.05)
+    for _ in range(3):
+        out = subprocess.run(["curl", "-sS", "-m", "30", "-A", UA, url], capture_output=True, timeout=35)
+        if out.returncode == 0:
+            return out.stdout.decode("utf-8", "replace")
+        time.sleep(1)
+    return ""
+
+
+def slugify(name):
+    return "ccolore_" + re.sub(r"[^a-z0-9가-힣]+", "-", re.sub(r"[®™()\[\]]", " ", name).strip().lower()).strip("-")
+
+
+def classify(name):
+    n = name.lower()
+    if re.search(r"자[켓캣]|자켓|후드|재킷|jacket|머플러|양말|삭스|socks|비니|글러브|장갑", n):
+        return "clothing"
+    if re.search(r"실타프|타프\b|tarp", n) and "폴" not in n and "파우치" not in n:
+        return "tarp"
+    if re.search(r"텐트|tent", n):
+        return "tent"
+    if re.search(r"사이드월|이너|그라운드시트|풋프린트", n):
+        return "tent_acc"
+    if re.search(r"에어라이트|얼티밋라이트|썸머라이트|슬립스퀘어|다운\s*라이너|침낭|퀼트|슬리핑", n):
+        return "sleeping_bag"
+    if re.search(r"파우치|압축색|메쉬망|스터프|pouch|색\b|케이스|case", n):
+        return "pouch"
+    if re.search(r"폴대|폴\b|pole|스트링|스토퍼|스트랩|strap|코드락|v팩|커버|카라비너|스테이크|펙|양말", n):
+        return "etc"
+    return "etc"
+
+
+def clean_name_color(title):
+    t = html.unescape(title).strip()
+    t = re.sub(r"^\[(시즌오프|season\s*off|품절)\]\s*", "", t, flags=re.I)  # 세일 태그만 제거(콜라보 태그는 유지)
+    color = ""
+    if " - " in t:
+        head, tail = t.rsplit(" - ", 1)
+        tail = tail.strip()
+        # 색상 후보: 코드/사이즈/수량(2ea·4set·1pcs) 제외
+        if tail and not re.search(r"\d{3,}|사이즈|size|\d+\s*(ea|set|pcs|개)\b", tail, re.I) and len(tail) <= 12:
+            color = tail
+            t = head.strip()
+    return t.strip(), color
+
+
+def color_english(ko):
+    """한글 색상 → 영문(color 필드). 미등재 토큰은 그대로."""
+    if not ko:
+        return ""
+    return " ".join(KO_COLOR_EN.get(w, w) for w in ko.split())
+
+
+REAL_SIZE = re.compile(r"^(XXS|XS|S|M|L|XL|XXL|XXXL|FREE|REGULAR|LONG|WIDE|F)$", re.I)
+
+
+def kr_sizes(t):
+    """옵션 select 에서 '진짜 사이즈'만(S/M/L 등). 애드온(폴·펙 Nea·세트·색상)은 제외 —
+    타프·텐트의 실제 사이즈는 제품명에 있으므로 옵션 확장하면 쓰레기 행 폭발(코베아 룰)."""
+    sizes = []
+    for o in re.findall(r"<option[^>]*>([^<]+)</option>", t):
+        o = html.unescape(o).strip()
+        if re.search(r"선택|필수|SHIPPING|배송|-{3,}", o) or not o:
+            continue
+        s = re.sub(r"\s*[\[(].*$", "", o).strip()  # [품절]/(+원) 제거
+        if REAL_SIZE.match(s) and s.upper() not in [x.upper() for x in sizes]:
+            sizes.append(s.upper() if len(s) <= 3 else s)
+    return sizes
+
+
+def _clean_txt(t):
+    x = re.sub(r"<[^>]+>", "|", t.replace("&nbsp;", " "))
+    x = x.replace("\\r\\n", " ").replace("\r", " ").replace("\n", " ")
+    return re.sub(r"(\|\s*)+", "|", x)
+
+
+def _row_map(x, label, sizes):
+    """라벨 행 → {size: value}. 3형식: 컬럼표(529|548) · 인라인 사이즈별(S - 335g, M - 351g) · 단일(2,390g)."""
+    real = [s for s in sizes if s]
+    # 인라인 사이즈별: 'Full Weight | S - 335g, M - 351g'
+    m = re.search(re.escape(label) + r"\s*\|([^|]*?[A-Za-z]+\s*-\s*[\d,]+\s*g[^|]*)", x)
+    if m:
+        d = {}
+        for sm in re.finditer(r"([A-Za-z]{1,3})\s*-\s*([\d,]+(?:\.\d+)?)\s*g", m.group(1)):
+            d[sm.group(1).upper()] = float(sm.group(2).replace(",", ""))
+        if d:
+            return d
+    # 컬럼표: 'Full Weight | 529 | 548 | (g)' (이너사이즈 괄호값 무시)
+    m = re.search(re.escape(label) + r"\s*\|((?:\s*[\d,]+(?:\.\d+)?(?:\([\d.]+\))?\s*\|){1,4})", x)
+    if m:
+        nums = [float(n.replace(",", "")) for n in re.findall(r"([\d,]+(?:\.\d+)?)(?:\([\d.]+\))?", m.group(1))]
+        if len(nums) >= 2 and len(real) == len(nums):
+            return {real[i]: nums[i] for i in range(len(nums))}
+        if nums:
+            return {"": nums[0]}  # 단일값(콤마 포함 2,390 등)
+    # 단일값(g 병기): 'Full Weight | 2,390g'
+    m = re.search(re.escape(label) + r"\s*\|\s*([\d,]+(?:\.\d+)?)\s*g\b", x)
+    if m:
+        return {"": float(m.group(1).replace(",", ""))}
+    return {}
+
+
+def parse_weights(t, sizes):
+    """제품 무게 → {size: g}. Full/Total Weight 우선, 없으면 Weight/무게/총 무게(kg)."""
+    x = _clean_txt(t)
+    for lab in ("Full Weight", "Total Weight", "Weight"):
+        m = _row_map(x, lab, sizes)
+        if m:
+            return m
+    mk = re.search(r"총\s*무게\s*[:：|]?\s*([\d.]+)\s*kg", x)
+    if mk:
+        return {"": round(float(mk.group(1)) * 1000)}
+    mg = re.search(r"(?:무게|중량)\s*[:：|]?\s*([\d,]+(?:\.\d+)?)\s*g\b", x)
+    if mg:
+        return {"": float(mg.group(1).replace(",", ""))}
+    return {}
+
+
+def parse_bag_specs(t, sizes):
+    """침낭 스펙: 온도·필파워·충전재 + Fill Weight(사이즈별)."""
+    x = _clean_txt(t)
+    fillw = _row_map(x, "Fill Weight", sizes)
+    comfort = limit = None
+    mt = re.search(r"(-?\d+)\s*℃\s*/\s*(-?\d+)\s*℃(?:\s*/\s*(-?\d+)\s*℃)?", x)
+    if mt:
+        comfort, limit = int(mt.group(1)), int(mt.group(2))
+    fp = (re.search(r"필파워\s*[:：]?\s*(\d{3,4})", x)
+          or re.search(r"(\d{3,4})\s*CU\.?\s*IN", x, re.I)
+          or re.search(r"Goose Down\s*(\d{3,4})", x, re.I))
+    fillpower = int(fp.group(1)) if fp else None
+    fillmat = "down" if re.search(r"구스|덕다운|다운|goose|duck down", x, re.I) else ""
+    return {"fillw": fillw, "comfort": comfort, "limit": limit, "fillpower": fillpower, "fillmat": fillmat}
+
+
+def crawl():
+    listing = {}
+    page = 1
+    while page <= 15:
+        t = curl(f"{BASE}/product/list.html?cate_no={CATE}&page={page}")
+        blocks = re.split(r"anchorBoxId_", t)[1:]
+        if not blocks:
+            break
+        added = 0
+        for b in blocks:
+            mo = re.match(r"(\d+)", b)
+            if not mo:
+                continue
+            no = mo.group(1)
+            if no in listing:
+                continue
+            alt = re.search(r'alt="([^"]+)"', b)
+            if not alt:
+                continue
+            name = html.unescape(alt.group(1)).strip()
+            if not name or re.search(r"이미지|검색|메뉴|멀티몰|닫기|로고|배너|loading|_msize|_lsize|캘린더", name):
+                continue
+            img = re.search(r'src="(//[^"]+/web/product/(?:big|medium|small)[^"]+\.(?:jpg|png|gif))"', b)
+            image = ("https:" + img.group(1).split("?")[0]) if img else ""
+            listing[no] = (name, image)
+            added += 1
+        if added == 0:
+            break
+        page += 1
+    return listing
+
+
+def build(listing):
+    rows = []
+    total = len(listing)
+    for i, (no, (name_raw, image)) in enumerate(listing.items(), 1):
+        t = curl(f"{BASE}/product/detail.html?product_no={no}")
+        og = re.search(r'<meta property="og:title" content="([^"]+)"', t)
+        name, color = clean_name_color(og.group(1) if og else name_raw)
+        cat = classify(name)
+        gid = slugify(name)
+        sizes = kr_sizes(t) or [""]
+        specs0 = {}
+        wmap = parse_weights(t, sizes)  # {size: g} 또는 {"": g}
+        fillw_map = {}
+        if cat == "sleeping_bag":
+            sp = parse_bag_specs(t, sizes)
+            if sp["fillmat"]:
+                specs0["fillMaterial"] = sp["fillmat"]
+            if sp["fillpower"]:
+                specs0["fillPower"] = sp["fillpower"]
+            if sp["comfort"] is not None:
+                specs0["comfortTemp"] = sp["comfort"]
+            if sp["limit"] is not None:
+                specs0["limitTemp"] = sp["limit"]
+            fillw_map = sp["fillw"]
+        elif cat == "clothing" and re.search(r"구스|덕다운|다운|down", _clean_txt(t), re.I):
+            specs0["fillMaterial"] = "down"
+        single_w = wmap.get("")
+        for s in sizes:
+            sp = dict(specs0)
+            if cat == "sleeping_bag" and (fillw_map.get(s) or fillw_map.get("")):
+                sp["fillWeight"] = fillw_map.get(s) or fillw_map.get("")
+            skq = SIZE_KO.get(s.upper(), s) if s else ""
+            nm = f"{name} {s}".strip() if s else name            # 영문 사이즈
+            nm_ko = f"{name} {skq}".strip() if skq else name     # 한글 사이즈
+            rows.append({
+                "groupId": gid, "category": cat, "company": "ccolore", "companyKorean": "꼴로르",
+                "name": nm, "nameKorean": nm_ko,
+                "color": color_english(color), "colorKorean": color,  # color=영문, colorKorean=한글
+                "size": s, "sizeKorean": skq,
+                "weight": wmap.get(s, single_w) or 0,
+                "imageUrl": image, "specs": sp,
+                "_source": f"{BASE}/product/detail.html?product_no={no}",
+            })
+        if i % 10 == 0 or i == total:
+            print(f"  detail {i}/{total} (rows {len(rows)})", flush=True)
+    return rows
+
+
+def main():
+    out = sys.argv[1] if len(sys.argv) > 1 else "out/ccolore-FINAL.json"
+    listing = crawl()
+    print(f"리스팅 {len(listing)}개 → 상세 수집", flush=True)
+    rows = build(listing)
+    best = {}
+    for r in rows:
+        k = (r["groupId"], r["color"], r["size"])
+        if k not in best or (bool(r["weight"]), len(r["specs"])) > (bool(best[k]["weight"]), len(best[k]["specs"])):
+            best[k] = r
+    dd = list(best.values())
+    json.dump(dd, open(out, "w"), ensure_ascii=False, indent=2)
+    print(f"완료: {len(rows)}행 → 중복제거 {len(dd)}행 -> {out}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/crawl-gear/sites/ccolore.js
+++ b/.claude/skills/crawl-gear/sites/ccolore.js
@@ -1,0 +1,6 @@
+// 꼴로르(CCOLORE) — Cafe24 한국공식(ccolore.com). 초경량 다운 침낭/퀼트 + 실타프·텐트·다운의류.
+// 실제 크롤은 standalone `ccolore.py`. 측정표(사이즈별 Full Weight/Fill Weight)+온도(N℃/N℃/N℃)+필파워 파싱.
+//   크롤: python3 ccolore.py out/ccolore-FINAL.json  ·  미리보기: node crawl.js ccolore --from-json=out/ccolore-FINAL.json
+export default { name:'ccolore', company:'ccolore', companyKorean:'꼴로르',
+  baseUrl:'https://ccolore.com', defaultCategories:[],
+  crawl: async () => { throw new Error('ccolore.py 로 크롤하세요'); } };


### PR DESCRIPTION
## 요약
꼴로르(Cafe24 한국공식) 초경량 다운 침낭 카탈로그를 크롤링해 Firestore에 적재했습니다. (77행 / inserted 77, failed 0)

## 작업 내용
- **ccolore.py** — Cafe24 크롤러 (초경량 다운 침낭/퀼트 + 실타프·텐트·다운의류)
  - 침낭 **측정표** 파싱: 사이즈별(M/L) Full Weight(제품무게)·Fill Weight(충전량) + 온도(2℃/-3℃/-15℃→comfort/limit) + 필파워(3~4자리) + 충전재(구스다운)
  - **무게 4형식**: 컬럼표(529/548)·콤마단일(2,390g)·인라인 사이즈별(S-335g)·총무게kg
  - **애드온 옵션 제외** — 타프 폴·펙(8ea)·세트가 사이즈로 오염 → 진짜 사이즈만 확장(행 폭발 방지)
- **ccolore-weight-ocr.py** — CL/CT 실타프·사이드월은 무게가 텍스트 없이 이미지에만 → `Full Weight Ng(Skin)` OCR 추출(스킨 본체 우선)
- **color=영문 / colorKorean=한글** — 사이트가 한글 색상만 표기 → KO_COLOR_EN 사전으로 영문 변환(솔트 그레이→Salt Grey)
- **SKILL.md 룰 보강** — 출력 검증 체크리스트에 `color`(영문)/`colorKorean`(한글) 필드언어 항목 추가

## 커버리지
- sleeping_bag 25 · clothing 19 · tarp 9 · etc 12 · tent_acc 6 · pouch 4 · tent 2
- 무게 61/77 (침낭 25/25·타프 9/9·tent_acc 6/6; 미커버는 폴·스트링·파우치 등 하드웨어)

🤖 Generated with [Claude Code](https://claude.com/claude-code)