### PR TITLE
장비 공유 랜딩 /gear-share/:id (GD-7)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import LogInView from './alert/login/LogInView';
 import AppInstallView from './app-install/AppInstallView';
 import BagShareWrapper from './bag-share/component/BagShareWrapper.tsx';
 import CampShareWrapper from './camp-share/component/CampShareWrapper.tsx';
+import GearShareWrapper from './gear-share/component/GearShareWrapper.tsx';
 import CelebrateView from './celebrate/CelebrateView';
 import AndroidAppBannerView from './components/AndroidAppBannerView';
 import ManageView from './manage/ManageView';
@@ -21,6 +22,10 @@ const ROUTES = [
   {
     path: '/camp-share/:id',
     element: <CampShareWrapper />,
+  },
+  {
+    path: '/gear-share/:id',
+    element: <GearShareWrapper />,
   },
   { path: '/manage', element: <ManageView /> },
   { path: '/celebrate', element: <CelebrateView /> },

--- a/src/gear-share/component/GearShareView.tsx
+++ b/src/gear-share/component/GearShareView.tsx
@@ -1,0 +1,218 @@
+import { FC, useCallback } from 'react';
+import { observer } from 'mobx-react-lite';
+import GearShare from '../model/GearShare';
+
+interface Props {
+  gearShare: GearShare;
+}
+
+const APP_STORE_URL = 'https://apps.apple.com/kr/app/id6751174681';
+const PLAY_STORE_URL =
+  'https://play.google.com/store/apps/details?id=kr.co.useless.app';
+
+const isAndroid = /Android/i.test(navigator.userAgent);
+
+// 장비 공유 랜딩(GD-7). 장비 정보를 보여주고 '앱에서 보기'로 딥링크한다.
+// 앱 미설치 시 스토어로 폴백(박지 공유 CS-7과 동일 구조).
+const GearShareView: FC<Props> = ({ gearShare }) => {
+  const openApp = useCallback(() => {
+    const scheme = `lessismoreapp://gear-detail/${gearShare.getId()}`;
+    const storeUrl = isAndroid ? PLAY_STORE_URL : APP_STORE_URL;
+
+    let fallback: ReturnType<typeof setTimeout> | null = null;
+
+    const cancelFallback = () => {
+      if (fallback) {
+        clearTimeout(fallback);
+        fallback = null;
+      }
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+
+    const onVisibility = () => {
+      if (document.hidden) {
+        cancelFallback();
+      }
+    };
+
+    document.addEventListener('visibilitychange', onVisibility);
+
+    fallback = setTimeout(() => {
+      cancelFallback();
+      window.location.href = storeUrl;
+    }, 1500);
+
+    window.location.href = scheme;
+  }, [gearShare]);
+
+  if (!gearShare.isInitialized()) {
+    return (
+      <div style={styles.center}>
+        <p style={styles.muted}>불러오는 중…</p>
+      </div>
+    );
+  }
+
+  if (gearShare.isNotFound()) {
+    return (
+      <div style={styles.center}>
+        <p style={styles.muted}>장비 정보를 찾을 수 없어요.</p>
+        <a href='https://useless.my' style={styles.linkMuted}>
+          useless 홈으로
+        </a>
+      </div>
+    );
+  }
+
+  const imageUrl = gearShare.getImageUrl();
+  const metaLine = gearShare.getMetaLine();
+  const weightLabel = gearShare.getWeightLabel();
+
+  return (
+    <div style={styles.page}>
+      <div style={styles.card}>
+        {imageUrl ? (
+          <img src={imageUrl} alt={gearShare.getName()} style={styles.image} />
+        ) : (
+          <div style={styles.imagePlaceholder} />
+        )}
+
+        <div style={styles.body}>
+          <div style={styles.infoRow}>
+            <div style={styles.infoText}>
+              <p style={styles.company}>{gearShare.getCompany()}</p>
+              <h1 style={styles.title}>{gearShare.getName()}</h1>
+              {metaLine && <p style={styles.meta}>{metaLine}</p>}
+            </div>
+            {weightLabel && (
+              <div style={styles.weightBox}>
+                <span style={styles.weightCaption}>무게</span>
+                <span style={styles.weight}>{weightLabel}</span>
+              </div>
+            )}
+          </div>
+
+          <button type='button' style={styles.cta} onClick={openApp}>
+            앱에서 보기
+          </button>
+          <p style={styles.ctaHint}>
+            useless 앱이 없으면 앱스토어로 이동해요
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const styles: Record<string, React.CSSProperties> = {
+  page: {
+    minHeight: '100vh',
+    backgroundColor: '#F5F5F5',
+    display: 'flex',
+    justifyContent: 'center',
+    padding: '20px 16px 40px',
+    boxSizing: 'border-box',
+  },
+  card: {
+    width: '100%',
+    maxWidth: 480,
+    backgroundColor: '#FFFFFF',
+    borderRadius: 16,
+    overflow: 'hidden',
+    boxShadow: '0 4px 24px rgba(0,0,0,0.08)',
+  },
+  image: {
+    width: '100%',
+    aspectRatio: '1 / 1',
+    objectFit: 'contain',
+    display: 'block',
+    backgroundColor: '#F1F1F1',
+  },
+  imagePlaceholder: {
+    width: '100%',
+    aspectRatio: '1 / 1',
+    backgroundColor: '#F1F1F1',
+  },
+  body: {
+    padding: 20,
+  },
+  infoRow: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  infoText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  company: {
+    fontSize: 13,
+    color: '#000000',
+    margin: 0,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 700,
+    color: '#000000',
+    margin: '2px 0 0',
+  },
+  meta: {
+    fontSize: 13,
+    color: '#767676',
+    margin: '6px 0 0',
+  },
+  weightBox: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-end',
+    flexShrink: 0,
+  },
+  weightCaption: {
+    fontSize: 11,
+    color: '#767676',
+  },
+  weight: {
+    fontSize: 16,
+    fontWeight: 700,
+    color: '#000000',
+    marginTop: 2,
+  },
+  cta: {
+    width: '100%',
+    marginTop: 24,
+    padding: '16px 0',
+    border: 'none',
+    borderRadius: 12,
+    backgroundColor: '#000000',
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: 600,
+    cursor: 'pointer',
+  },
+  ctaHint: {
+    fontSize: 12,
+    color: '#767676',
+    textAlign: 'center',
+    marginTop: 8,
+  },
+  center: {
+    minHeight: '100vh',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    backgroundColor: '#F5F5F5',
+  },
+  muted: {
+    fontSize: 15,
+    color: '#767676',
+  },
+  linkMuted: {
+    fontSize: 14,
+    color: '#555555',
+  },
+};
+
+export default observer(GearShareView);

--- a/src/gear-share/component/GearShareWrapper.tsx
+++ b/src/gear-share/component/GearShareWrapper.tsx
@@ -1,0 +1,19 @@
+import { FC, useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { observer } from 'mobx-react-lite';
+import GearShare from '../model/GearShare';
+import GearShareView from './GearShareView';
+
+// 장비 공유 랜딩(GD-7) 진입. /gear-share/:id 에서 장비를 로드해 표시한다.
+const GearShareWrapper: FC = () => {
+  const { id } = useParams();
+  const [gearShare] = useState(() => GearShare.from(id ?? ''));
+
+  useEffect(() => {
+    void gearShare.initialize();
+  }, [gearShare]);
+
+  return <GearShareView gearShare={gearShare} />;
+};
+
+export default observer(GearShareWrapper);

--- a/src/gear-share/model/GearShare.ts
+++ b/src/gear-share/model/GearShare.ts
@@ -1,0 +1,117 @@
+import { makeAutoObservable } from 'mobx';
+import { doc, getDoc } from 'firebase/firestore';
+import app from '../../App';
+
+// 장비 공유 랜딩(GD-7)에서 표시할 장비 정보. Firestore `/gear/{id}`(카탈로그, 공개 읽기)를 읽는다.
+export interface GearData {
+  name?: string;
+  nameKorean?: string;
+  company?: string;
+  companyKorean?: string;
+  weight?: string | number;
+  imageUrl?: string;
+  category?: string;
+  color?: string;
+  colorKorean?: string;
+}
+
+const CATEGORY_LABEL: Record<string, string> = {
+  tent: '텐트',
+  sleepingBag: '침낭',
+  backpack: '배낭',
+  clothing: '의류',
+  mat: '매트',
+  furniture: '가구',
+  lantern: '랜턴',
+  cooking: '조리',
+  electronic: '전자기기',
+  food: '음식',
+  etc: '기타',
+};
+
+class GearShare {
+  public static from(id: string) {
+    return new GearShare(id);
+  }
+
+  private gear: GearData | null = null;
+  private initialized = false;
+  private notFound = false;
+
+  private constructor(private readonly id: string) {
+    makeAutoObservable(this);
+  }
+
+  public async initialize() {
+    try {
+      const snapshot = await getDoc(
+        doc(app.getFirebase().getStore(), 'gear', this.id)
+      );
+
+      if (!snapshot.exists()) {
+        this.setNotFound(true);
+      } else {
+        this.setGear(snapshot.data() as GearData);
+      }
+    } catch (e) {
+      console.error('장비 조회 실패:', e);
+      this.setNotFound(true);
+    } finally {
+      this.setInitialized(true);
+    }
+  }
+
+  private setGear(value: GearData) {
+    this.gear = value;
+  }
+
+  private setInitialized(value: boolean) {
+    this.initialized = value;
+  }
+
+  private setNotFound(value: boolean) {
+    this.notFound = value;
+  }
+
+  public isInitialized() {
+    return this.initialized;
+  }
+
+  public isNotFound() {
+    return this.notFound;
+  }
+
+  public getId() {
+    return this.id;
+  }
+
+  public getName() {
+    return this.gear?.nameKorean || this.gear?.name || '';
+  }
+
+  public getCompany() {
+    return this.gear?.companyKorean || this.gear?.company || '';
+  }
+
+  public getWeightLabel() {
+    const w = this.gear?.weight;
+
+    return w != null && String(w).length > 0 ? `${w}g` : '';
+  }
+
+  public getImageUrl() {
+    return this.gear?.imageUrl ?? '';
+  }
+
+  // 카테고리 · 색상 메타 라인(앱 상세와 동일 톤). 둘 다 없으면 빈 문자열.
+  public getMetaLine() {
+    const category = this.gear?.category
+      ? CATEGORY_LABEL[this.gear.category] ?? ''
+      : '';
+    const color = this.gear?.colorKorean || this.gear?.color || '';
+
+    return [category, color].filter(Boolean).join(' · ');
+  }
+}
+
+export default GearShare;


### PR DESCRIPTION
앱(lessismore-app)의 장비 공유 대상 웹 랜딩. /gear-share/:id → Firestore /gear/{id} 읽어 제조사·이름·무게·카테고리·사진 표시 → '앱에서 보기'로 lessismoreapp://gear-detail/{id} 딥링크(미설치 스토어 폴백). camp-share와 동일 구조. vite build·로컬 preview 렌더 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)