### PR TITLE
크롤-기어: 백컨트리(국내) 어댑터 추가, Firestore push 완료(427개)

### DIFF
--- a/.claude/skills/crawl-gear/backcountry-weight-ocr.py
+++ b/.claude/skills/crawl-gear/backcountry-weight-ocr.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+# 백컨트리 크롤 JSON에 무게를 채운다. 스펙(무게/사이즈/소재)이 텍스트가 아니라 상세페이지
+# 이미지(_specImages, 크롤 단계에서 이미 URL만 모아둠) 안에 인쇄되어 있어 macOS Vision
+# OCR로 읽는다. "무게"/"중량"/"Weight" 라벨 뒤의 첫 숫자+단위(g/kg/gram/그램)를 그 상품의
+# 무게로 채택 — AMG티타늄 세션에서 확립한 라벨 기반 매칭 원칙(포지션이 아니라 라벨로 찾기)을
+# 따르되, 이 브랜드의 스펙표는 라벨 열과 값 열이 분리돼 있어(예: "Weight"와 "2100 g"가 서로
+# 다른 OCR 텍스트 블록) 같은 문자열 안에서 라벨+값을 못 찾는 경우가 많다 — 그래서 라벨
+# 매칭이 실패하면 Vision이 주는 바운딩박스로 "같은 행(row)"에 있는 값 블록을 찾는 폴백을 쓴다.
+#
+# Usage: python3 backcountry-weight-ocr.py <crawl-json> [out-json]
+import json
+import os
+import re
+import sys
+import tempfile
+import urllib.parse
+import urllib.request
+
+import Vision
+import Quartz
+from Foundation import NSURL
+from PIL import Image
+
+UA = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+CACHE = os.path.join(tempfile.gettempdir(), "backcountry-ocr-cache")
+os.makedirs(CACHE, exist_ok=True)
+
+# 1,000g 이상 무게는 "1,786g" 처럼 천단위 콤마가 붙는다 — 숫자 패턴에 콤마 허용 필수.
+NUM = r"[\d,]+(?:\.\d+)?"
+UNIT = r"(g|gr|kg|gram|그램)"  # 캡처 그룹 — kg/g 판별에 실제 매치된 단위 텍스트를 써야 한다
+WEIGHT_RE = re.compile(rf"(?:중\s*량|무\s*게|weight)\s*(?:\([^)]*\))?\s*[:：]?\s*({NUM})\s*{UNIT}\b", re.I)
+STANDALONE_TOKEN_RE = re.compile(rf"^({NUM})\s*{UNIT}$", re.I)
+# macOS Vision이 이 브랜드 상세이미지에 자주 쓰이는 이탤릭체 "g"를 숫자 "9"로 잘못 읽는다
+# (실측: "165.5g"→"165.59"). 라벨/정상 표기가 다 실패했을 때만 쓰는 최후 폴백 —
+# "NNN.N9"(소수점 한 자리+9로 끝남) 꼴을 "NNN.Ng"로 재해석한다.
+MISREAD_G_AS_9_RE = re.compile(r"^(\d+\.\d)9$")
+# 텐트류는 "무게: Ng" 단일 값이 아니라 "스킨:899g / 프레임:413g" 처럼 스킨(플라이)+프레임(폴대)
+# 분리 표기 + "Total: 1,312g" 합계로 나오는 경우가 흔하다. Total 라인의 콤마를 Vision이
+# 마침표로 오독해("1,312g"→"1.312g") 합계값을 그대로 못 믿으므로, 스킨+프레임을 직접 더한다.
+SKIN_RE = re.compile(rf"스\s*킨\s*[:：]?\s*({NUM})\s*{UNIT}", re.I)
+FRAME_RE = re.compile(rf"프\s*레\s*임\s*[:：]?\s*({NUM})\s*{UNIT}", re.I)
+# 라벨-값이 표의 다른 열(별개 OCR 블록)로 나뉜 경우의 "라벨만" 매칭 — 정확히 이 단어만 있는
+# 블록이어야 한다("Fill weight"·"충전량"·"제품구성" 같은 다른 스펙과 혼동 방지).
+LABEL_ONLY_RE = re.compile(r"^(?:중\s*량|무\s*게|weight)$", re.I)
+VALUE_NUM_RE = re.compile(rf"({NUM})\s*{UNIT}\b", re.I)
+
+
+# 이 브랜드가 파는 캠핑 장비(텐트·침낭·매트·코펠·스토브 등)는 아무리 무거워도 15kg을 넘지
+# 않는다 — OCR이 근처 텍스트를 섞어 읽어 "100000g" 같은 터무니없는 값을 만드는 경우(실측:
+# 매트 상품에서 발견)를 걸러내는 안전판. 이 범위 밖이면 해당 후보를 아예 버린다(집합에서 제외해
+# "값 1개로 확정" 로직이 오염되지 않게).
+MAX_PLAUSIBLE_G = 15000
+# 상품 갤러리에 번들 액세서리(예: 티타늄 쿠커에 딸려오는 다이니마 수납파우치) 설명이 같이
+# 실려있으면, row-pairing이 그 액세서리 표의 "Weight: 4gram"을 본품 무게로 잘못 채택하는
+# 경우가 실측됐다(예: "티타늄 싱글쿠커 600ml"가 4g으로 나옴 — 명백히 파우치 무게). 실제
+# 캠핑 장비 중 가장 가벼운 축(작은 클립·펙 등)도 대체로 10g은 넘으므로, 그 아래는 신뢰하지
+# 않고 버린다 — 틀린 값보다 미확정이 낫다는 원칙을 여기도 동일하게 적용.
+MIN_PLAUSIBLE_G = 10
+
+
+def _to_grams(num_str, unit_str):
+    v = float(num_str.replace(",", ""))
+    return v * 1000 if unit_str.lower() == "kg" else v
+
+
+def _add_if_plausible(vals, grams):
+    if MIN_PLAUSIBLE_G <= grams <= MAX_PLAUSIBLE_G:
+        vals.add(grams)
+
+
+def fetch(url):
+    safe_url = urllib.parse.quote(url, safe=":/?=&%")
+    req = urllib.request.Request(safe_url, headers={"User-Agent": UA})
+    with urllib.request.urlopen(req, timeout=20) as r:
+        return r.read()
+
+
+def ocr_image(path):
+    """이미지 한 장을 OCR해 {text, cx, cy} 리스트로 반환한다.
+    cx/cy는 Vision의 정규화 좌표(0~1, 원점 좌하단) 중심점 — 같은 이미지 안에서
+    라벨/값을 같은 행(row)으로 매칭할 때 쓴다."""
+    url = NSURL.fileURLWithPath_(str(path))
+    src = Quartz.CGImageSourceCreateWithURL(url, None)
+    if src is None:
+        return []
+    cg = Quartz.CGImageSourceCreateImageAtIndex(src, 0, None)
+    req = Vision.VNRecognizeTextRequest.alloc().init()
+    req.setRevision_(3)
+    req.setRecognitionLevel_(0)
+    req.setUsesLanguageCorrection_(False)
+    req.setRecognitionLanguages_(["ko-KR", "en-US"])
+    handler = Vision.VNImageRequestHandler.alloc().initWithCGImage_options_(cg, None)
+    handler.performRequests_error_([req], None)
+    out = []
+    for obs in req.results() or []:
+        cand = obs.topCandidates_(1)
+        if not cand:
+            continue
+        bb = obs.boundingBox()
+        out.append(
+            {
+                "text": cand[0].string(),
+                "cx": bb.origin.x + bb.size.width / 2,
+                "cy": bb.origin.y + bb.size.height / 2,
+                "h": bb.size.height,
+            }
+        )
+    return out
+
+
+def ocr_product_images(image_urls):
+    """상품의 스펙 이미지 전체를 OCR한다. 반환값은 이미지(타일)별로 묶인
+    관측치 리스트의 리스트 — 같은 행 매칭은 같은 이미지 안에서만 유효하므로
+    이미지 경계를 유지한다."""
+    per_image = []
+    for i, url in enumerate(image_urls):
+        try:
+            raw = fetch(url)
+        except Exception as e:
+            print(f"  download fail {url}: {e}", file=sys.stderr)
+            continue
+        key = re.sub(r"[^A-Za-z0-9_.]", "_", url.split("/")[-1]) or f"img{i}"
+        path = os.path.join(CACHE, key)
+        with open(path, "wb") as f:
+            f.write(raw)
+        try:
+            im = Image.open(path)
+            w, h = im.size
+        except Exception as e:
+            print(f"  open fail {path}: {e}", file=sys.stderr)
+            continue
+        tile_h = 1500
+        if h <= tile_h * 1.3:
+            obs = ocr_image(path)
+            if obs:
+                per_image.append(obs)
+            continue
+        for y in range(0, h, tile_h):
+            box = (0, y, w, min(y + tile_h, h))
+            tile_path = os.path.join(CACHE, f"{key}_{y}.jpg")
+            if not os.path.exists(tile_path):
+                im.crop(box).convert("RGB").save(tile_path, quality=90)
+            obs = ocr_image(tile_path)
+            if obs:
+                per_image.append(obs)
+    return per_image
+
+
+def _row_paired_values(per_image):
+    """라벨("무게"/"중량"/"Weight")만 있는 블록을 찾아 같은 행(비슷한 y, 더 오른쪽 x)의
+    값 블록에서 숫자+단위를 뽑는다. 라벨/값이 표의 다른 열로 나뉜 경우의 폴백."""
+    vals = set()
+    for obs in per_image:
+        labels = [o for o in obs if LABEL_ONLY_RE.match(o["text"].strip())]
+        if not labels:
+            continue
+        for label in labels:
+            candidates = [o for o in obs if o is not label and o["cx"] > label["cx"]]
+            if not candidates:
+                continue
+            row_tol = max(label["h"], 0.01) * 1.5
+            same_row = [o for o in candidates if abs(o["cy"] - label["cy"]) <= row_tol]
+            pool = same_row or candidates
+            best = min(pool, key=lambda o: abs(o["cy"] - label["cy"]))
+            m = VALUE_NUM_RE.search(best["text"])
+            if m:
+                _add_if_plausible(vals, _to_grams(m.group(1), m.group(2)))
+    return vals
+
+
+def resolve_weight(image_urls):
+    per_image = ocr_product_images(image_urls)
+    texts = [o["text"] for obs in per_image for o in obs]
+
+    vals = set()
+    for t in texts:
+        m = WEIGHT_RE.search(t)
+        if m:
+            _add_if_plausible(vals, _to_grams(m.group(1), m.group(2)))
+    if len(vals) == 1:
+        return next(iter(vals)), "ocr_label"
+    if len(vals) > 1:
+        # 라벨 붙은 값이 여러 개면(사이즈별 표 등) 가장 흔한 값을 못 고르니 포기하고
+        # 이후 폴백도 시도하지 않는다 — 잘못된 값을 넣는 것보다 낫다.
+        return None, None
+
+    row_vals = _row_paired_values(per_image)
+    if len(row_vals) == 1:
+        return next(iter(row_vals)), "ocr_row_paired"
+    if len(row_vals) > 1:
+        return None, None
+
+    skin_vals, frame_vals = set(), set()
+    for t in texts:
+        m = SKIN_RE.search(t)
+        if m:
+            _add_if_plausible(skin_vals, _to_grams(m.group(1), m.group(2)))
+        m = FRAME_RE.search(t)
+        if m:
+            _add_if_plausible(frame_vals, _to_grams(m.group(1), m.group(2)))
+    if len(skin_vals) == 1 and len(frame_vals) == 1:
+        total = next(iter(skin_vals)) + next(iter(frame_vals))
+        if total <= MAX_PLAUSIBLE_G:
+            return total, "ocr_skin_frame_sum"
+        return None, None
+    if len(skin_vals) > 1 or len(frame_vals) > 1:
+        return None, None
+
+    standalone = set()
+    for t in texts:
+        m = STANDALONE_TOKEN_RE.match(t.strip())
+        if m:
+            _add_if_plausible(standalone, _to_grams(m.group(1), m.group(2)))
+    if len(standalone) == 1:
+        return next(iter(standalone)), "ocr_standalone"
+
+    misread = set()
+    for t in texts:
+        m = MISREAD_G_AS_9_RE.match(t.strip())
+        if m:
+            _add_if_plausible(misread, float(m.group(1)))
+    if len(misread) == 1:
+        return next(iter(misread)), "ocr_misread_g_as_9"
+    return None, None
+
+
+def main():
+    crawl_path = sys.argv[1]
+    out_path = sys.argv[2] if len(sys.argv) > 2 else crawl_path
+    data = json.load(open(crawl_path, encoding="utf-8"))
+
+    by_product = {}
+    for row in data:
+        by_product.setdefault(row["_productNo"], []).append(row)
+
+    resolved = {}
+    total = len(by_product)
+    for i, (pno, rows) in enumerate(by_product.items(), 1):
+        image_urls = rows[0].get("_specImages") or []
+        if image_urls:
+            w, src = resolve_weight(image_urls)
+            if w is not None:
+                resolved[pno] = (w, src)
+        if i % 10 == 0:
+            print(f"progress {i}/{total}", file=sys.stderr)
+
+    n = 0
+    for row in data:
+        pno = row["_productNo"]
+        if pno in resolved:
+            w, src = resolved[pno]
+            row["weight"] = w
+            row["_weightSource"] = src
+            n += 1
+
+    json.dump(data, open(out_path, "w", encoding="utf-8"), ensure_ascii=False, indent=1)
+    print(f"무게 채움: {n}/{len(data)}행 ({len(resolved)}/{total}개 상품) -> {out_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/crawl-gear/brands/backcountry.md
+++ b/.claude/skills/crawl-gear/brands/backcountry.md
@@ -1,0 +1,22 @@
+# 백컨트리 (backcountry, 국내 브랜드)
+
+- **공식**: https://m.backcountry.co.kr (Cafe24 모바일 스킨, 국내 전용 브랜드 — 영문명 없음)
+- 크롤러: `sites/backcountry.js`(리스팅+스펙이미지 수집), 무게 OCR `backcountry-weight-ocr.py`
+- 마지막 크롤: 2026-07-15, 427개 (고유 groupId 219개)
+
+## ⚠️ 주의사항
+
+1. **`_source`(카테고리 URL) 하나에 실제 카테고리가 여러 개 섞여 있다.** `cate_no`가 사이트 자체 대분류라 내부 카테고리 키와 1:N 매핑됨:
+   - `cate_no=24` → tent/tarp/shelter/mat 혼재
+   - `cate_no=25` → tarp/shelter/tent_acc 혼재
+   - `cate_no=26` → sleeping_bag/mat 혼재
+   - `cate_no=28` → cookware_etc/table/chair/bottle/cup/cutlery/backpack 혼재
+   - `cate_no=43` → etc/backpack/stove 혼재
+   - `cate_no=44` → stove/lighting 혼재
+   - `cate_no=46` → etc/backpack 혼재
+   - **push 전에 반드시 `_source`를 `backcountry_<category>`로 재작성해 1:1로 맞출 것.** 그대로 push하면 `push.js`가 그룹 첫 항목 카테고리로 나머지를 전부 덮어씀 (2026-07-15 세션에서 실제로 겪음, push 직전 발견해 수정).
+2. **리스팅 페이지네이션**: URL 파라미터 없이 "더보기" 버튼이 AJAX로 이어붙임(`$M.displayMore`) — puppeteer로 버튼을 `more_total_page` 횟수만큼 클릭해야 전체 목록이 나온다.
+3. **스펙/무게가 텍스트가 아니라 상세 이미지 안**(`.ThumbImage`, 특히 `product/extra/big/` 경로). 크롤 단계는 `_specImages`만 모으고, 무게는 `backcountry-weight-ocr.py`(macOS Vision OCR)로 별도 채움. 구조화 spec 필드(재질/용량 등)는 **아직 미추출 상태** — 다음 작업으로 남음.
+4. **무게 수집률 56%(241/427)에 그침.** 특히 `cookware_etc`(24%), `etc`(29%), `mat`(47%), `table`(40%), `stove`(48%)가 낮음 — 이미지 자체에 중량 표기가 없거나 OCR 매칭 실패로 추정. 재시도 여지 있음(다른 상세 이미지·타일 분할 재조정).
+5. **색상 옵션이 "색상+번들타입" 복합값**으로 옴 (예: "쉐이드 타프쉘(올리브그린) 단품"). 괄호 안 색상어만 우선 추출(`KO_COLOR_EN` 사전) → 미매칭 시 로마자 음역 폴백.
+6. **영문명이 아예 없어 로마자 음역(RR)으로 `name`을 생성.** 순수 발음전사라 외래어/브랜드명 인식이 없어 부자연스러운 표기가 섞임 (예: "쉘터 라이트 에디션" → "Swelteo Raiteu Edisyeon"). 검수 시 참고.

--- a/.claude/skills/crawl-gear/sites/backcountry.js
+++ b/.claude/skills/crawl-gear/sites/backcountry.js
@@ -1,0 +1,275 @@
+// 백컨트리(Backcountry, 국내 브랜드) — m.backcountry.co.kr, Cafe24 모바일 스킨.
+// 리스팅: /product/list_thumb.html?cate_no=N, 서버렌더 + "더보기" 버튼이 AJAX로 다음
+//   10개씩 이어붙인다($M.displayMore(...)) — 페이지네이션 URL 파라미터가 없어 puppeteer로
+//   "더보기" 버튼을 more_total_page 횟수만큼 클릭해야 전체 목록이 로드된다.
+// 상세: 표준 Cafe24 상품상세(select[name=option1]로 색상 옵션). 스펙(무게/사이즈/소재)이
+//   텍스트가 아니라 상세 이미지(.ThumbImage, 특히 "product/extra/big/" 경로) 안에 인쇄되어
+//   있어 크롤 단계에서는 이미지 URL만 모으고(_specImages), 무게는 별도
+//   backcountry-weight-ocr.py(macOS Vision OCR)에서 채운다 — 크롤-기어 관례.
+const BASE = 'https://m.backcountry.co.kr';
+const UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+
+// ── 한글 로마자 표기(RR) — 국내 전용 브랜드라 영문명이 없어 name(영문)을 이걸로 채운다 ──
+const RR_INITIALS = ['g', 'kk', 'n', 'd', 'tt', 'r', 'm', 'b', 'pp', 's', 'ss', '', 'j', 'jj', 'ch', 'k', 't', 'p', 'h'];
+const RR_MEDIALS = ['a', 'ae', 'ya', 'yae', 'eo', 'e', 'yeo', 'ye', 'o', 'wa', 'wae', 'oe', 'yo', 'u', 'wo', 'we', 'wi', 'yu', 'eu', 'ui', 'i'];
+const RR_FINALS = ['', 'k', 'k', 'k', 'n', 'n', 'n', 't', 'l', 'k', 'm', 'l', 'l', 'l', 'p', 'l', 'm', 'p', 'p', 't', 't', 'ng', 't', 't', 'k', 't', 'p', 't'];
+const romanizeSyllable = (code) => {
+  const base = code - 0xac00;
+  const initial = Math.floor(base / (21 * 28));
+  const medial = Math.floor((base % (21 * 28)) / 28);
+  const final = base % 28;
+  return RR_INITIALS[initial] + RR_MEDIALS[medial] + RR_FINALS[final];
+};
+const romanize = (text) => {
+  let out = '';
+  for (const ch of text) {
+    const code = ch.codePointAt(0);
+    out += code >= 0xac00 && code <= 0xd7a3 ? romanizeSyllable(code) : ch;
+  }
+  return out;
+};
+const capitalizeFirstLetter = (s) => {
+  const idx = s.search(/[a-zA-Z]/);
+  return idx === -1 ? s : s.slice(0, idx) + s[idx].toUpperCase() + s.slice(idx + 1);
+};
+const romanizeToken = (token) => (/[가-힣]/.test(token) ? capitalizeFirstLetter(romanize(token)) : token);
+const romanizeName = (koreanText) =>
+  koreanText
+    .split(/(\s+)/)
+    .map((t) => (/\s+/.test(t) ? t : romanizeToken(t)))
+    .join('');
+
+// 색상 select 옵션이 순수 색상이 아니라 "색상+번들타입"이 섞인 복합값이라("쉐이드
+// 타프쉘(올리브그린) 단품" 등) color(영문)를 이 사전으로 우선 추출하고, 매칭 안 되는
+// 단어는 로마자 음역으로 폴백한다.
+const KO_COLOR_EN = {
+  올리브그린: 'Olive Green', 차콜블랙: 'Charcoal Black', 웜그레이: 'Warm Gray',
+  미들그레이: 'Middle Gray', 라이트그레이: 'Light Gray', 다크그레이: 'Dark Gray',
+  블랙: 'Black', 화이트: 'White', 그레이: 'Gray', 그린: 'Green', 올리브: 'Olive',
+  카키: 'Khaki', 베이지: 'Beige', 브라운: 'Brown', 네이비: 'Navy', 블루: 'Blue',
+  레드: 'Red', 오렌지: 'Orange', 옐로우: 'Yellow', 옐로: 'Yellow', 차콜: 'Charcoal',
+  웜: 'Warm', 다크: 'Dark', 라이트: 'Light', 실버: 'Silver', 골드: 'Gold',
+  코요테: 'Coyote', 샌드: 'Sand', 우드랜드: 'Woodland', 퍼플: 'Purple', 핑크: 'Pink',
+};
+const translateColorWord = (koWord) => {
+  if (KO_COLOR_EN[koWord]) return KO_COLOR_EN[koWord];
+  // 사전에 없으면 긴 색상 키워드부터 부분매치 시도(복합어 대응), 실패하면 로마자 음역.
+  const sorted = Object.keys(KO_COLOR_EN).sort((a, b) => b.length - a.length);
+  const hit = sorted.find((k) => koWord.includes(k));
+  if (hit) return KO_COLOR_EN[hit];
+  return capitalizeFirstLetter(romanize(koWord));
+};
+// colorKorean(전체 옵션 텍스트, 번들타입 포함)에서 괄호 안 색상어만 뽑아 영문 변환.
+// 괄호가 없으면 옵션 텍스트 전체를 색상어로 보고 변환.
+const colorEnOf = (colorKorean) => {
+  const m = colorKorean.match(/\(([^)]+)\)/);
+  const target = m ? m[1] : colorKorean;
+  return translateColorWord(target.replace(/\s+/g, ''));
+};
+
+const CATEGORY_MAP = {
+  24: 'tent', // 텐트 & 쉘터
+  26: 'sleeping_bag', // 침낭 & 침구류
+  25: 'tarp', // 타프 & 타프 폴
+  28: 'cookware_etc', // 쿠커 & 테이블
+  44: 'stove', // 렌턴 & 스토브
+  46: 'etc', // 보관 & 운행
+  43: 'etc', // 악세사리 & 기타
+};
+const CATEGORY_KO = {
+  24: '텐트 & 쉘터',
+  26: '침낭 & 침구류',
+  25: '타프 & 타프 폴',
+  28: '쿠커 & 테이블',
+  44: '렌턴 & 스토브',
+  46: '보관 & 운행',
+  43: '악세사리 & 기타',
+};
+
+// 카테고리 안에서도 품목이 섞여있어(예: 24엔 텐트뿐 아니라 쉘터·타프도, 28엔 쿠커·테이블·컵
+// 다 섞임) 이름 키워드로 세부 분류한다. 위에서부터 먼저 매치되는 것 우선.
+const classify = (cateNo, name) => {
+  const n = name;
+  if (/타프쉘|쉐이드\s*타프|타프\s*쉘/.test(n)) return 'shelter';
+  if (/타프/.test(n)) return 'tarp';
+  if (/쉘터/.test(n)) return 'tent'; // 백컨트리 "쉘터"류는 자립형 소형 텐트에 가까움
+  if (/침낭|슬리핑\s*백/.test(n)) return 'sleeping_bag';
+  if (/매트|에어매트|폼매트/.test(n)) return 'mat';
+  if (/베개|필로우/.test(n)) return 'pillow';
+  if (/테이블/.test(n)) return 'table';
+  if (/체어|의자/.test(n)) return 'chair';
+  if (/머그|컵\b/.test(n)) return 'cup';
+  if (/보울|그릇/.test(n)) return 'bowl';
+  if (/수저|스푼|포크|젓가락|커트러리/.test(n)) return 'cutlery';
+  if (/물통|보틀/.test(n)) return 'bottle';
+  if (/랜턴|랜턴|조명|라이트\b/.test(n)) return 'lighting';
+  if (/스토브|버너|화목난로/.test(n)) return 'stove';
+  if (/토치/.test(n)) return 'torch';
+  if (/타프폴|폴대|텐트폴|서브폴/.test(n)) return 'tent_acc';
+  if (/가방|파우치|백팩|배낭/.test(n)) return 'backpack';
+  return CATEGORY_MAP[cateNo] ?? 'etc';
+};
+
+const UA_HEADERS = { 'User-Agent': UA, Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' };
+
+const slugify = (s) =>
+  s.trim().replace(/\s+/g, '-').replace(/[^\p{L}\p{N}()-]/gu, '').toLowerCase();
+
+const dismissPopup = async (page) => {
+  await page
+    .evaluate(() => {
+      const btn = [...document.querySelectorAll('a,button')].find((b) => /close|닫기/i.test(b.textContent || '') || /close/i.test(b.className || ''));
+      if (btn) btn.click();
+    })
+    .catch(() => {});
+};
+
+// "더보기" 버튼을 more_total_page 만큼 클릭해 카테고리 전체 상품을 로드.
+const loadAllProducts = async (page) => {
+  const totalPage = await page.evaluate(() => {
+    const el = document.getElementById('more_total_page');
+    return el ? parseInt(el.textContent, 10) : 1;
+  });
+  for (let i = 1; i < totalPage; i++) {
+    await page.evaluate(() => {
+      const btn = [...document.querySelectorAll('a')].find((a) => a.textContent.includes('더보기'));
+      if (btn) btn.click();
+    });
+    await new Promise((r) => setTimeout(r, 700));
+  }
+  return page.evaluate(() => {
+    const seen = new Set();
+    const out = [];
+    document.querySelectorAll('a[href*="product_no"]').forEach((a) => {
+      const url = new URL(a.href);
+      const no = url.searchParams.get('product_no');
+      const name = a.textContent.trim();
+      if (!no || !name || seen.has(no)) return;
+      seen.add(no);
+      const img = a.querySelector('img') || a.closest('li')?.querySelector('img');
+      out.push({
+        productNo: no,
+        nameKorean: name,
+        detailUrl: `${location.origin}/product/detail.html?product_no=${no}`,
+        imageUrl: img ? img.src.split('?')[0] : '',
+      });
+    });
+    return out;
+  });
+};
+
+const fetchCategoryListing = async (page, cateNo) => {
+  await page.goto(`${BASE}/product/list_thumb.html?cate_no=${cateNo}`, { waitUntil: 'networkidle2', timeout: 60000 });
+  await dismissPopup(page);
+  await new Promise((r) => setTimeout(r, 500));
+  return loadAllProducts(page);
+};
+
+const fetchDetail = async (page, item) => {
+  await page.goto(item.detailUrl, { waitUntil: 'networkidle2', timeout: 60000 });
+  // dismissPopup(상단 배너 닫기 클릭)을 여기서 부르면 그 클릭이 유발하는 레이아웃 변화 때문에
+  // 상세설명(NNEditor) lazy-load 스크립트의 리스너 등록이 깨진다(실측 확인) — headless로 DOM만
+  // 읽는 우리는 팝업이 보여도 무해하므로 상세페이지에서는 아예 호출하지 않는다.
+  // 카테고리 리스팅(더보기 반복 클릭으로 썸네일 수십 개 로드)을 거친 직후 상세페이지로 넘어오면
+  // networkidle2 가 찍힌 뒤에도 상세설명의 lazy-load 스크립트가 아직 리스너를 안 붙인 상태라
+  // 바로 스크롤해도 안 걸린다(실측: 400ms 로는 거의 항상 실패, 2000ms 는 안정적으로 성공).
+  await new Promise((r) => setTimeout(r, 2000));
+  const basic = await page.evaluate(() => {
+    const select = document.querySelector('select[name="option1"]');
+    const colors = select
+      ? [...select.options].filter((o) => o.value && o.value !== '*' && o.value !== '**' && !/^-+$/.test(o.text.trim())).map((o) => o.text.trim())
+      : [];
+    const priceEl = [...document.querySelectorAll('*')].find((e) => e.children.length === 0 && /^\d[\d,]*원$/.test(e.textContent.trim()));
+    const imgs = [...document.querySelectorAll('img.ThumbImage')].map((i) => i.src.split('?')[0]).filter((s) => /\/web\/product\//.test(s));
+    const mainImage = imgs[0] || '';
+    const specImages = imgs.slice(1);
+    return { colors, mainImage, specImages, priceText: priceEl ? priceEl.textContent.trim() : '' };
+  });
+  // 상세설명(NNEditor) 이미지는 lazy-load라 스크롤해야 실제 src가 채워진다. 스펙표(무게 등)가
+  // 상품 갤러리(.ThumbImage)가 아니라 여기(상세설명 영역)에만 있는 경우가 많다 — 이 세션에서
+  // 스크린샷으로 확인된 실제 원인. 고정 sleep 은 크롤 루프처럼 같은 page 를 계속 재사용하며
+  // 연속 navigate 할 때 lazy-load 완료 전에 읽어버려 항상 placeholder 1장만 잡히는 문제가
+  // 있었다 — waitForFunction 으로 실제 로드 완료(2장 이상)를 능동 대기.
+  await page.evaluate(async () => {
+    const total = document.body.scrollHeight;
+    for (let y = 0; y < total; y += 400) {
+      window.scrollTo(0, y);
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    window.scrollTo(0, document.body.scrollHeight);
+  });
+  await page
+    .waitForFunction(
+      () => [...document.querySelectorAll('img')].filter((i) => /\/web\/upload\/NNEditor\//.test(i.src)).length > 1,
+      { timeout: 5000 }
+    )
+    .catch(() => {});
+  await new Promise((r) => setTimeout(r, 300));
+  const descImages = await page.evaluate(() =>
+    [...document.querySelectorAll('img')].map((i) => i.src.split('?')[0]).filter((s) => /\/web\/upload\/NNEditor\//.test(s))
+  );
+  return { ...basic, specImages: [...basic.specImages, ...descImages] };
+};
+
+const buildRows = (item, category, detail) => {
+  const colors = detail.colors.length ? detail.colors : [''];
+  const nameEnglish = romanizeName(item.nameKorean);
+  return colors.map((colorKorean) => ({
+    groupId: `backcountry_${slugify(item.nameKorean)}`,
+    category,
+    company: 'backcountry',
+    companyKorean: '백컨트리',
+    name: colorKorean ? `${nameEnglish} / ${colorEnOf(colorKorean)}` : nameEnglish,
+    nameKorean: colorKorean ? `${item.nameKorean} ${colorKorean}` : item.nameKorean,
+    color: colorKorean ? colorEnOf(colorKorean) : '',
+    colorKorean,
+    size: '',
+    sizeKorean: '',
+    weight: 0, // OCR 스크립트(backcountry-weight-ocr.py)에서 채움
+    imageUrl: detail.mainImage || item.imageUrl,
+    specs: {},
+    _source: `${BASE}/product/list_thumb.html?cate_no=${item._cateNo}`,
+    _detailUrl: item.detailUrl,
+    _productNo: item.productNo,
+    _specImages: detail.specImages,
+  }));
+};
+
+export default {
+  name: 'backcountry',
+  company: 'backcountry',
+  companyKorean: '백컨트리',
+  baseUrl: BASE,
+  defaultCategories: Object.keys(CATEGORY_MAP),
+  crawl: async (browser, { categoryUrls, withWeight = true } = {}) => {
+    const cateNos = categoryUrls?.length ? categoryUrls : Object.keys(CATEGORY_MAP);
+    const page = await browser.newPage();
+    await page.setUserAgent(UA);
+    await page.setViewport({ width: 480, height: 900 });
+
+    const all = [];
+    for (const cateNo of cateNos) {
+      console.log(`[backcountry] crawling cate_no=${cateNo} (${CATEGORY_KO[cateNo] ?? ''})`);
+      const items = await fetchCategoryListing(page, cateNo);
+      console.log(`[backcountry]   ${items.length} listing items`);
+      let i = 0;
+      for (const item of items) {
+        i += 1;
+        item._cateNo = cateNo;
+        try {
+          const detail = withWeight
+            ? await fetchDetail(page, item)
+            : { colors: [], mainImage: '', specImages: [], priceText: '' };
+          const category = classify(cateNo, item.nameKorean);
+          all.push(...buildRows(item, category, detail));
+        } catch (e) {
+          console.log(`[backcountry]   error on ${item.productNo}: ${e.message} — skipping`);
+        }
+        if (i % 10 === 0) console.log(`[backcountry]   detail ${i}/${items.length}`);
+      }
+    }
+    await page.close();
+    return all;
+  },
+};


### PR DESCRIPTION
## Summary
- 백컨트리(m.backcountry.co.kr, 국내 전용 브랜드) 크롤 어댑터(`sites/backcountry.js`) 및 무게 OCR 후처리 스크립트(`backcountry-weight-ocr.py`) 추가
- 427개 상품(고유 groupId 219개) 크롤 후 Firestore `gear` 컬렉션에 push 완료(신규 403 / 갱신 24 / 실패 0)
- `brands/backcountry.md`에 이번 세션에서 겪은 주의사항 기록: `_source`(cate_no)에 여러 카테고리가 섞여 있어 push 전 재정리가 필요했던 이슈, 무게 수집률(56%), 로마자 음역 한계 등

## Test plan
- [x] dry-run으로 `_source`→카테고리 1:1 매핑 확인 후 실제 push
- [x] push 결과 inserted=403 updated=24 failed=0 확인

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>