### PR TITLE
공지/신기능 팝업 어드민 — 보관함+발행+실시간 미리보기 (/announcement)

### DIFF
--- a/docs/announcement/AnnouncementAdminSpec.md
+++ b/docs/announcement/AnnouncementAdminSpec.md
@@ -1,0 +1,146 @@
+# 공지 / 신기능 팝업 어드민 기능 스펙 (보관함 + 발행)
+
+## 1. 개요
+
+앱(`lessismore-app`)의 **인앱 공지 바텀시트**와 **신기능 안내 팝업**을 원격으로 제어하는 어드민 화면이다. 앱은 Firestore **라이브 단일 문서**만 실시간(`onSnapshot`) 구독하고, 어드민은 여기에 **보관함(초안·이력) + 발행** 모델을 얹는다.
+
+- 같은 Firebase 프로젝트(`lessismore-7e070`)를 공유하므로, 라이브 문서 쓰기가 곧 앱 노출이다.
+- 앱 쪽 동작 명세는 앱 레포 `specs/Announcement.md` 참고. 이 문서는 **어드민 화면**만 다룬다.
+- 앱 쪽 계약(라이브 문서 스키마)은 **변경 금지**.
+
+## 2. 라우트 / 접근 제어
+
+- 라우트: **`/announcement`** (manage와 병렬, `App.tsx` `ROUTES`에 등록).
+- 접근 제어는 `manage`와 **동일한 `ALLOWED_UIDS`**(`src/common/AllowedUids.ts`)를 공유한다.
+  1. 비로그인 → Google 로그인 버튼만 표시.
+  2. 로그인했지만 미허용 UID → "접근 권한이 없습니다."
+  3. 허용 UID → 탭 화면 렌더 (각 탭의 데이터 로딩 중에는 Spin 표시).
+- ⚠️ 접근 제어는 **클라이언트 사이드**다. 실제 쓰기 보호는 Firestore 보안 규칙(`config/*`, `announcements/*`, `feature-popups/*` 쓰기를 허용 UID로 제한)에 의존한다 — **레포 범위 밖(콘솔 작업)**.
+
+## 3. 데이터 모델
+
+### 3.1 라이브 문서 (앱 계약 — 변경 금지)
+
+앱이 실시간 구독하는 단일 문서. 어드민의 "발행"이 이 문서를 덮어쓴다.
+
+**`config/announcement`** — 텍스트 공지 바텀시트
+
+| 필드 | 타입 | 비고 |
+| --- | --- | --- |
+| `id` | string | 공지 식별자. **바꾸면 새 공지**로 인식돼, 닫았던 사용자에게도 다시 뜬다 |
+| `active` | boolean | 표시 on/off |
+| `message` | string | 본문(필수) |
+| `link` | string? | (선택) 이동 대상. 앱 내부 경로(`/bag`) 또는 `http(s)://` |
+| `startAt` / `endAt` | string?(ISO) | (선택) 노출 기간 |
+
+**`config/featurePopup`** — 신기능 안내 중앙 카드 팝업
+
+| 필드 | 타입 | 비고 |
+| --- | --- | --- |
+| `id` | string | 팝업 식별자. **닫음이 id 단위 영구 저장**이라, id가 바뀌면 닫았던 사용자에게도 다시 뜬다 |
+| `active` | boolean | 표시 on/off |
+| `title` | string | 제목(필수, 줄바꿈 허용) |
+| `subtitle` | string? | (선택) 보조 문구 |
+| `items` | array? | (선택) 소개 항목. **앱은 앞 3개만 렌더**. 각 항목: `{ imageUrl?, title, description?, link? }` |
+| `buttonLabel` | string? | (선택) 주 버튼 문구. 비면 앱 기본 '확인' |
+| `buttonLink` | string? | (선택) 주 버튼 이동 대상 |
+| `showSkip` | boolean? | (선택) 건너뛰기 노출. 기본 true |
+| `startAt` / `endAt` | string?(ISO) | (선택) 노출 기간 |
+
+### 3.2 보관함 컬렉션 (어드민 전용 — 앱은 읽지 않음)
+
+문서 키 = 항목의 `id` 필드. 옵셔널 필드는 **값이 있을 때만 저장**(빈 문자열 저장 금지).
+
+**`announcements/{id}`**
+
+| 필드 | 타입 | 비고 |
+| --- | --- | --- |
+| `id`, `message`, `link?`, `startAt?`, `endAt?` | — | 라이브 문서와 동일 의미 (`active` 없음 — 발행이 노출을 결정) |
+| `createdAt` | string(ISO) | 최초 저장 시각. **신규일 때만** 기록(같은 id로 재저장 시 유지) |
+| `updatedAt` | string(ISO) | 저장할 때마다 갱신. 목록 정렬 기준 |
+
+**`feature-popups/{id}`**
+
+| 필드 | 타입 | 비고 |
+| --- | --- | --- |
+| `id`, `title`, `subtitle?`, `items?`, `buttonLabel?`, `buttonLink?`, `startAt?`, `endAt?` | — | 라이브 문서와 동일 의미 (`active` 없음) |
+| `showSkip` | boolean | 폼 Switch 값을 **항상 저장**(기본 ON=true). 명시 저장으로 발행 시 모호함 제거 |
+| `createdAt` / `updatedAt` | string(ISO) | announcements와 동일 규칙 |
+
+## 4. 기능 명세
+
+### 4.1 발행 모델
+
+- **발행** = 선택한 보관함 항목의 **콘텐츠 필드**를 라이브 문서에 `active: true`와 함께 `setDoc`(전체 덮어쓰기). `createdAt`/`updatedAt`은 라이브 문서에 넣지 않는다.
+- **끄기** = 라이브 문서의 `active`만 `false`로 저장(문서·나머지 필드 유지). `active`가 true일 때만 가능.
+- **내리기(삭제)** = 라이브 문서 `deleteDoc`. confirm 후 실행. 보관함은 영향 없음.
+- 보관함 항목 **삭제** = 보관함에서만 지움. **라이브 노출에 영향 없음**(confirm 문구에 명시).
+
+### 4.2 UI 구조 (한 페이지, antd)
+
+`AnnouncementAdminView.tsx`는 **셸**: 접근 제어 + 제목 + `Tabs` 2개.
+
+1. **공지 탭** — `AnnouncementTabView.tsx`
+2. **신기능 팝업 탭** — `FeaturePopupTabView.tsx`
+
+각 탭 공통 구성(위→아래):
+
+**라이브 상태 카드**
+- 현재 라이브 문서를 `getDoc` 1회 조회(발행/끄기/내리기 후 상태 갱신).
+- 표시: id, 본문(공지=message) / 제목(팝업=title) 요약, active 상태 Tag(ON/OFF), 기간.
+- 액션: [끄기](active=false 저장, active일 때만 활성), [내리기](deleteDoc, confirm).
+- 라이브 문서 없으면 "발행된 항목 없음".
+
+**보관함 목록 (antd Table)**
+- 컬럼: id · 요약(공지=message 앞부분 / 팝업=title) · 기간(startAt~endAt, 없으면 '-') · 수정일(updatedAt) · 액션([발행] [편집] [삭제]).
+- `updatedAt` 내림차순(`query` + `orderBy('updatedAt', 'desc')`).
+- 라이브 문서와 id가 같은 행에 'LIVE' Tag.
+- 상단 [새로 만들기] 버튼.
+
+**작성/편집 폼 (antd Modal + Form)**
+- 공지 폼: `id`(필수) · `message`(필수, TextArea) · `link`(선택) · `startAt`/`endAt`(DatePicker showTime, 선택). ~~active 스위치~~ 제거 — **발행이 노출을 결정**.
+- 팝업 폼: `id`(필수) · `title`(필수, TextArea 2줄 — 줄바꿈 허용) · `subtitle`(선택) · **`items`: `Form.List`(최대 3개)** — 각 항목 imageUrl(선택)/title(필수)/description(선택)/link(선택), 항목 추가·삭제 버튼(3개 도달 시 추가 버튼 숨김) · `buttonLabel`(선택, 비면 앱 기본 '확인' 안내) · `buttonLink`(선택) · `showSkip`(Switch, 기본 ON) · `startAt`/`endAt`(선택).
+- 저장 → 보관함 컬렉션에 `setDoc`(문서 키 = id, `createdAt`은 신규일 때만, `updatedAt` 항상 갱신) 후 목록 갱신.
+- **편집 중 id 변경** = 새 항목으로 저장됨(기존 항목은 남음)을 폼 extra로 안내. 바뀐 id가 기존 다른 항목과 같으면 그 항목을 덮어쓴다(createdAt은 그 항목 것 유지).
+
+**앱 화면 미리보기 (작성/편집 Modal 내)**
+- 두 탭의 작성/편집 Modal은 **좌측 폼 + 우측 미리보기**의 좌우 배치다(공지 width 840 / 팝업 960, flex row + `flexWrap: 'wrap'`으로 좁은 화면에서 세로 낙하).
+- 미리보기는 고정 크기 **폰 프레임**(약 320×640, 라운드 16, 테두리 `#E5E5E5`) 안에 앱 화면 위 딤(`rgba(0,0,0,0.5)`)이 깔린 모습을 렌더하고, 프레임 밖 상단에 "앱 미리보기" 캡션을 둔다.
+  - 공지: 프레임 **하단 앵커 바텀 시트** 재현 — 그랩 핸들 · 본문(줄바꿈 유지, 비면 플레이스홀더) · link 입력 시 "자세히 보기" 밑줄 텍스트 · [닫기]/[하루동안 보지않기] 버튼 행.
+  - 팝업: 프레임 **중앙 카드** 재현 — 제목(줄바꿈 유지, 비면 플레이스홀더) · 부제목 · 소개 항목 리스트(제목이 입력된 항목만, 썸네일 이미지 로드 실패 시 회색 박스 폴백, link 있으면 chevron) · 메인 버튼(buttonLabel 비면 '확인') · showSkip ON일 때 "건너뛰기".
+- **실시간 갱신**: `Form.useWatch`로 관련 필드(공지 message/link, 팝업 title/subtitle/items/buttonLabel/showSkip)를 구독해 입력 즉시 미리보기에 반영한다. `useWatch`는 Modal이 닫혀 있어도 안전하다.
+- 미리보기는 **앱 원본 대비 비율 축소 재현**이다(폰 프레임이 실제 기기보다 작아 수치를 축소·근사). 픽셀 정합 목적이 아니라 구성·문안 확인 목적. 폰트는 웹 레포에 이미 로드된 Pretendard(+시스템 폴백)를 쓴다.
+- 미리보기 컴포넌트는 순수 프레젠테이션(FC, 상태는 이미지 onError 폴백 정도만)이다.
+
+**발행 confirm**
+- "이 항목을 라이브로 발행할까요?"
+- 라이브 문서와 다른 id를 발행하면 "닫았던 사용자에게도 새로 노출됩니다" 안내. **팝업 탭은 특히 강조**(닫음이 id 단위 영구 저장).
+- 발행 성공 시 `message.success` + 라이브 카드 갱신.
+
+### 4.3 날짜 처리
+
+- 폼은 dayjs, 저장은 ISO 문자열. 변환·표시는 `AdminDateUtil.ts`(`toIsoString` / `toDayjs` / `formatDateTime` / `formatPeriod`)로 통일.
+
+## 5. 파일 구성
+
+| 파일 | 역할 |
+| --- | --- |
+| `src/announcement/AnnouncementAdminView.tsx` | 셸(접근 제어 + Tabs) |
+| `src/announcement/AnnouncementTabView.tsx` | 공지 탭(라이브 카드 + 보관함 목록 + 폼 + 발행) |
+| `src/announcement/FeaturePopupTabView.tsx` | 신기능 팝업 탭(동일 구성 + items Form.List) |
+| `src/announcement/AdminDateUtil.ts` | ISO ↔ dayjs 변환·표시 유틸 |
+| `src/announcement/AnnouncementPreview.tsx` | 공지 바텀 시트 미리보기(폰 프레임, 순수 프레젠테이션) |
+| `src/announcement/FeaturePopupPreview.tsx` | 신기능 팝업 미리보기(폰 프레임, 순수 프레젠테이션) |
+
+두 탭의 스키마가 달라 라이브 로드/발행/목록 로드 로직은 **각 탭에 단순 중복**을 허용한다(억지 공용화 금지). 공용은 날짜 유틸 수준만.
+
+## 6. 검증 / 리뷰
+
+- `npm run lint`, `npm run build`(`tsc -b && vite build`) 통과.
+- 스펙 컴플라이언스 + 코드 품질 2단계 리뷰.
+
+## 7. 범위 밖 / 미해결
+
+- Firestore 보안 규칙 배포: 콘솔 작업(레포 밖). 이 화면은 UI 게이팅만.
+- 이미지 업로드(팝업 items의 imageUrl): URL 직접 입력만 지원. 업로드 연동은 후순위.
+- 예약 발행(특정 시각 자동 발행): `startAt`/`endAt`으로 노출 기간만 제어. 발행 자체는 수동.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import GearShareWrapper from './gear-share/component/GearShareWrapper.tsx';
 import CelebrateView from './celebrate/CelebrateView';
 import AndroidAppBannerView from './components/AndroidAppBannerView';
 import ManageView from './manage/ManageView';
+import AnnouncementAdminView from './announcement/AnnouncementAdminView';
 
 const ROUTES = [
   {
@@ -28,6 +29,7 @@ const ROUTES = [
     element: <GearShareWrapper />,
   },
   { path: '/manage', element: <ManageView /> },
+  { path: '/announcement', element: <AnnouncementAdminView /> },
   { path: '/celebrate', element: <CelebrateView /> },
   { path: '/app-install', element: <AppInstallView /> },
   { path: '*', element: <Navigate to='/app-install' replace /> },

--- a/src/announcement/AdminDateUtil.ts
+++ b/src/announcement/AdminDateUtil.ts
@@ -1,0 +1,35 @@
+import dayjs, { Dayjs } from 'dayjs';
+
+// 어드민 화면에서 쓰는 ISO 문자열 ↔ dayjs 변환·표시 유틸.
+
+export const toIsoString = (value?: Dayjs): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  return value.toISOString();
+};
+
+export const toDayjs = (value?: string): Dayjs | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  return dayjs(value);
+};
+
+export const formatDateTime = (value?: string): string => {
+  if (!value) {
+    return '-';
+  }
+
+  return dayjs(value).format('YYYY-MM-DD HH:mm');
+};
+
+export const formatPeriod = (startAt?: string, endAt?: string): string => {
+  if (!startAt && !endAt) {
+    return '-';
+  }
+
+  return `${formatDateTime(startAt)} ~ ${formatDateTime(endAt)}`;
+};

--- a/src/announcement/AnnouncementAdminView.tsx
+++ b/src/announcement/AnnouncementAdminView.tsx
@@ -1,0 +1,118 @@
+import { observer } from 'mobx-react-lite';
+import { Tabs } from 'antd';
+import app from '../App';
+import { ALLOWED_UIDS } from '../common/AllowedUids';
+import AnnouncementTabView from './AnnouncementTabView';
+import FeaturePopupTabView from './FeaturePopupTabView';
+
+// 공지/신기능 팝업 어드민 셸. 접근 제어(로그인 → 허용 UID)를 통과하면 탭 2개를 렌더한다.
+// 데이터 로드·발행 로직은 각 탭(AnnouncementTabView / FeaturePopupTabView)이 담당한다.
+const AnnouncementAdminView = () => {
+  const firebase = app.getFirebase();
+  const isLoggedIn = firebase.isLoggedIn();
+  const userId = firebase.getUserId();
+  const isAllowed = ALLOWED_UIDS.includes(userId);
+
+  const handleClickGoogle = async () => {
+    await firebase.logInWithGoogle();
+  };
+
+  if (!isLoggedIn) {
+    return (
+      <div
+        style={{
+          width: '100%',
+          height: '100vh',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <button
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: 'black',
+            color: 'white',
+            border: 'none',
+            padding: '12px 20px',
+            borderRadius: '8px',
+            fontSize: '16px',
+            fontWeight: 'bold',
+            cursor: 'pointer',
+            transition: 'background 0.3s',
+          }}
+          onClick={handleClickGoogle}
+        >
+          <svg
+            style={{
+              width: '24px',
+              height: '24px',
+              marginRight: '10px',
+            }}
+            viewBox='0 0 24 24'
+          >
+            <path
+              fill='#4285F4'
+              d='M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z'
+            />
+            <path
+              fill='#34A853'
+              d='M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z'
+            />
+            <path
+              fill='#FBBC05'
+              d='M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z'
+            />
+            <path
+              fill='#EA4335'
+              d='M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z'
+            />
+          </svg>
+          <span>Google로 로그인</span>
+        </button>
+      </div>
+    );
+  }
+
+  if (!isAllowed) {
+    return (
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100vh',
+        }}
+      >
+        <h1>접근 권한이 없습니다.</h1>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ maxWidth: 880, margin: '32px auto', padding: '0 20px' }}>
+      <h1 style={{ fontSize: 28, fontWeight: 700, marginBottom: 20, color: '#222' }}>
+        공지 / 신기능 팝업 관리
+      </h1>
+      <Tabs
+        defaultActiveKey='announcement'
+        items={[
+          {
+            key: 'announcement',
+            label: '공지',
+            children: <AnnouncementTabView />,
+          },
+          {
+            key: 'featurePopup',
+            label: '신기능 팝업',
+            children: <FeaturePopupTabView />,
+          },
+        ]}
+      />
+    </div>
+  );
+};
+
+export default observer(AnnouncementAdminView);

--- a/src/announcement/AnnouncementPreview.tsx
+++ b/src/announcement/AnnouncementPreview.tsx
@@ -1,0 +1,125 @@
+import { FC } from 'react';
+
+// 앱 공지 바텀 시트 미리보기 props. 폼 입력값을 그대로 받아 렌더한다.
+interface Props {
+  message: string;
+  link?: string;
+}
+
+const PREVIEW_FONT_FAMILY = "'Pretendard', -apple-system, 'Apple SD Gothic Neo', sans-serif";
+
+// 앱의 공지 바텀 시트를 폰 프레임 안에 축소 재현하는 순수 프레젠테이션 컴포넌트.
+const AnnouncementPreview: FC<Props> = ({ message, link }) => {
+  return (
+    <div style={{ fontFamily: PREVIEW_FONT_FAMILY }}>
+      <div style={{ fontSize: 12, color: '#767676', marginBottom: 8 }}>앱 미리보기</div>
+      <div
+        style={{
+          width: 320,
+          height: 640,
+          backgroundColor: '#FFFFFF',
+          borderRadius: 16,
+          border: '1px solid #E5E5E5',
+          overflow: 'hidden',
+          position: 'relative',
+        }}
+      >
+        {/* 앱 화면 위에 깔리는 딤 */}
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'flex-end',
+          }}
+        >
+          {/* 하단 앵커 시트 */}
+          <div
+            style={{
+              backgroundColor: '#FFFFFF',
+              borderTopLeftRadius: 20,
+              borderTopRightRadius: 20,
+              padding: '12px 20px 24px',
+            }}
+          >
+            {/* 그랩 핸들 */}
+            <div
+              style={{
+                width: 40,
+                height: 4,
+                borderRadius: 4,
+                backgroundColor: '#EBEBEB',
+                margin: '0 auto 12px',
+              }}
+            />
+            {message ? (
+              <div
+                style={{
+                  fontSize: 15,
+                  lineHeight: '22px',
+                  color: '#000000',
+                  whiteSpace: 'pre-wrap',
+                }}
+              >
+                {message}
+              </div>
+            ) : (
+              <div style={{ fontSize: 15, lineHeight: '22px', color: '#B0B8C1' }}>
+                본문을 입력하세요
+              </div>
+            )}
+            {link && (
+              <div
+                style={{
+                  marginTop: 12,
+                  fontSize: 14,
+                  fontWeight: 600,
+                  color: '#000000',
+                  textDecoration: 'underline',
+                }}
+              >
+                자세히 보기
+              </div>
+            )}
+            <div style={{ display: 'flex', gap: 12, marginTop: 12 }}>
+              <div
+                style={{
+                  flex: 1,
+                  height: 46,
+                  borderRadius: 8,
+                  backgroundColor: '#EBEBEB',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: 14,
+                  color: '#000000',
+                }}
+              >
+                닫기
+              </div>
+              <div
+                style={{
+                  flex: 1,
+                  height: 46,
+                  borderRadius: 8,
+                  backgroundColor: '#EBEBEB',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: 14,
+                  color: '#000000',
+                }}
+              >
+                하루동안 보지않기
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AnnouncementPreview;

--- a/src/announcement/AnnouncementTabView.tsx
+++ b/src/announcement/AnnouncementTabView.tsx
@@ -1,0 +1,486 @@
+import { useEffect, useState } from 'react';
+import {
+  Button,
+  Card,
+  DatePicker,
+  Descriptions,
+  Form,
+  Input,
+  message,
+  Modal,
+  Space,
+  Spin,
+  Table,
+  Tag,
+  Typography,
+} from 'antd';
+import { Dayjs } from 'dayjs';
+import { collection, deleteDoc, doc, getDoc, getDocs, orderBy, query, setDoc } from 'firebase/firestore';
+import app from '../App';
+import { formatDateTime, formatPeriod, toDayjs, toIsoString } from './AdminDateUtil';
+import AnnouncementPreview from './AnnouncementPreview';
+
+// 작성/편집 폼 값 형태. 날짜는 antd DatePicker와 맞물리도록 Dayjs로 다룬다.
+interface AnnouncementFormValues {
+  id: string;
+  message: string;
+  link?: string;
+  startAt?: Dayjs;
+  endAt?: Dayjs;
+}
+
+// 보관함(announcements/{id}) 문서 형태. 선택 필드는 값이 있을 때만 포함한다.
+interface AnnouncementArchiveDoc {
+  id: string;
+  message: string;
+  link?: string;
+  startAt?: string;
+  endAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// 라이브(config/announcement) 문서 형태 — 앱이 실시간 구독하는 계약이므로 변경 금지.
+interface AnnouncementLiveDoc {
+  id: string;
+  active: boolean;
+  message: string;
+  link?: string;
+  startAt?: string;
+  endAt?: string;
+}
+
+const LIVE_DOC_PATH = ['config', 'announcement'] as const;
+const ARCHIVE_COLLECTION = 'announcements';
+
+const AnnouncementTabView = () => {
+  const [form] = Form.useForm<AnnouncementFormValues>();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [liveDoc, setLiveDoc] = useState<AnnouncementLiveDoc | null>(null);
+  const [archiveList, setArchiveList] = useState<AnnouncementArchiveDoc[]>([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  // 미리보기 실시간 갱신용 폼 값 구독(Modal이 닫혀 있어도 안전).
+  const watchedMessage = Form.useWatch('message', form);
+  const watchedLink = Form.useWatch('link', form);
+
+  const firebase = app.getFirebase();
+
+  const getLiveDocRef = () => {
+    return doc(firebase.getStore(), ...LIVE_DOC_PATH);
+  };
+
+  const getArchiveDocRef = (id: string) => {
+    return doc(firebase.getStore(), ARCHIVE_COLLECTION, id);
+  };
+
+  const loadLive = async () => {
+    const snapshot = await getDoc(getLiveDocRef());
+
+    if (snapshot.exists()) {
+      setLiveDoc(snapshot.data() as AnnouncementLiveDoc);
+    } else {
+      setLiveDoc(null);
+    }
+  };
+
+  const loadArchive = async () => {
+    const snapshot = await getDocs(
+      query(collection(firebase.getStore(), ARCHIVE_COLLECTION), orderBy('updatedAt', 'desc'))
+    );
+
+    setArchiveList(snapshot.docs.map((item) => item.data() as AnnouncementArchiveDoc));
+  };
+
+  // 진입 시 라이브 문서와 보관함 목록을 1회 조회한다.
+  useEffect(() => {
+    const loadAll = async () => {
+      try {
+        await Promise.all([loadLive(), loadArchive()]);
+      } catch (error) {
+        console.error('공지 데이터 로드 실패:', error);
+        message.error('공지 데이터를 불러오지 못했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadAll();
+  }, []);
+
+  // 폼 값을 보관함 문서 형태로 변환. 선택 필드가 비면 키를 넣지 않는다(빈 문자열 저장 금지).
+  const buildArchivePayload = (values: AnnouncementFormValues): AnnouncementArchiveDoc => {
+    const id = values.id.trim();
+    const existing = archiveList.find((item) => item.id === id);
+    const now = new Date().toISOString();
+
+    const payload: AnnouncementArchiveDoc = {
+      id,
+      message: values.message.trim(),
+      createdAt: existing ? existing.createdAt : now,
+      updatedAt: now,
+    };
+
+    const link = values.link?.trim();
+
+    if (link) {
+      payload.link = link;
+    }
+
+    const startAt = toIsoString(values.startAt);
+
+    if (startAt) {
+      payload.startAt = startAt;
+    }
+
+    const endAt = toIsoString(values.endAt);
+
+    if (endAt) {
+      payload.endAt = endAt;
+    }
+
+    return payload;
+  };
+
+  // 보관함 항목의 콘텐츠 필드만 라이브 문서 형태로 변환(createdAt/updatedAt 제외, active: true).
+  const buildLivePayload = (item: AnnouncementArchiveDoc): AnnouncementLiveDoc => {
+    const payload: AnnouncementLiveDoc = {
+      id: item.id,
+      active: true,
+      message: item.message,
+    };
+
+    if (item.link) {
+      payload.link = item.link;
+    }
+
+    if (item.startAt) {
+      payload.startAt = item.startAt;
+    }
+
+    if (item.endAt) {
+      payload.endAt = item.endAt;
+    }
+
+    return payload;
+  };
+
+  const handleClickCreate = () => {
+    setEditingId(null);
+    form.resetFields();
+    setIsModalOpen(true);
+  };
+
+  const handleClickEdit = (item: AnnouncementArchiveDoc) => {
+    setEditingId(item.id);
+    form.setFieldsValue({
+      id: item.id,
+      message: item.message,
+      link: item.link ?? '',
+      startAt: toDayjs(item.startAt),
+      endAt: toDayjs(item.endAt),
+    });
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
+
+  // 보관함에 저장(문서 키 = id). 편집 중 id를 바꾸면 새 항목으로 저장되고 기존 항목은 남는다.
+  const handleSubmitForm = async () => {
+    let values: AnnouncementFormValues;
+
+    try {
+      values = await form.validateFields();
+    } catch {
+      // 필수값 누락 안내는 폼이 담당.
+      return;
+    }
+
+    setSaving(true);
+
+    try {
+      const payload = buildArchivePayload(values);
+
+      await setDoc(getArchiveDocRef(payload.id), payload);
+      await loadArchive();
+      setIsModalOpen(false);
+      message.success('보관함에 저장되었습니다.');
+    } catch (error) {
+      console.error('공지 저장 실패:', error);
+      message.error('저장에 실패했습니다.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // 발행: 보관함 항목을 active: true로 라이브 문서에 전체 덮어쓰기.
+  const handleClickPublish = (item: AnnouncementArchiveDoc) => {
+    const isNewId = !!liveDoc && liveDoc.id !== item.id;
+
+    Modal.confirm({
+      title: '이 항목을 라이브로 발행할까요?',
+      content: isNewId
+        ? `현재 라이브 공지(id: ${liveDoc?.id})와 id가 달라, 이전 공지를 닫았던 사용자에게도 새로 노출됩니다.`
+        : `id "${item.id}" 항목이 앱에 즉시 노출됩니다.`,
+      okText: '발행',
+      cancelText: '취소',
+      onOk: async () => {
+        try {
+          const payload = buildLivePayload(item);
+
+          await setDoc(getLiveDocRef(), payload);
+          setLiveDoc(payload);
+          message.success('발행되었습니다.');
+        } catch (error) {
+          console.error('공지 발행 실패:', error);
+          message.error('발행에 실패했습니다.');
+        }
+      },
+    });
+  };
+
+  // 끄기: 라이브 문서는 두고 active만 false로 저장해 노출만 중단한다.
+  const handleClickTurnOff = async () => {
+    if (!liveDoc) {
+      return;
+    }
+
+    try {
+      const payload: AnnouncementLiveDoc = { ...liveDoc, active: false };
+
+      await setDoc(getLiveDocRef(), payload);
+      setLiveDoc(payload);
+      message.success('노출을 껐습니다.');
+    } catch (error) {
+      console.error('공지 끄기 실패:', error);
+      message.error('끄기에 실패했습니다.');
+    }
+  };
+
+  // 내리기: 라이브 문서를 삭제해 공지를 완전히 제거한다(보관함은 유지).
+  const handleClickTakeDown = () => {
+    Modal.confirm({
+      title: '라이브 공지를 내리시겠습니까?',
+      content: '라이브 문서가 삭제되어 앱에서 공지가 완전히 사라집니다. 보관함 항목은 유지됩니다.',
+      okText: '내리기',
+      okButtonProps: { danger: true },
+      cancelText: '취소',
+      onOk: async () => {
+        try {
+          await deleteDoc(getLiveDocRef());
+          setLiveDoc(null);
+          message.success('라이브 공지를 내렸습니다.');
+        } catch (error) {
+          console.error('공지 내리기 실패:', error);
+          message.error('내리기에 실패했습니다.');
+        }
+      },
+    });
+  };
+
+  // 보관함 항목 삭제: 보관함에서만 지우며 라이브 노출에는 영향이 없다.
+  const handleClickDelete = (item: AnnouncementArchiveDoc) => {
+    Modal.confirm({
+      title: '보관함에서 삭제하시겠습니까?',
+      content: '보관함에서만 삭제되며, 라이브 노출에는 영향이 없습니다.',
+      okText: '삭제',
+      okButtonProps: { danger: true },
+      cancelText: '취소',
+      onOk: async () => {
+        try {
+          await deleteDoc(getArchiveDocRef(item.id));
+          await loadArchive();
+          message.success('삭제되었습니다.');
+        } catch (error) {
+          console.error('공지 보관함 삭제 실패:', error);
+          message.error('삭제에 실패했습니다.');
+        }
+      },
+    });
+  };
+
+  if (loading) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', padding: '60px 0' }}>
+        <Spin />
+      </div>
+    );
+  }
+
+  const columns = [
+    {
+      title: 'id',
+      dataIndex: 'id',
+      key: 'id',
+      render: (id: string) => (
+        <Space>
+          <span>{id}</span>
+          {liveDoc?.id === id && <Tag color='green'>LIVE</Tag>}
+        </Space>
+      ),
+    },
+    {
+      title: '요약',
+      dataIndex: 'message',
+      key: 'message',
+      render: (value: string) => (
+        <Typography.Text style={{ maxWidth: 240 }} ellipsis>
+          {value}
+        </Typography.Text>
+      ),
+    },
+    {
+      title: '기간',
+      key: 'period',
+      render: (_: unknown, item: AnnouncementArchiveDoc) => formatPeriod(item.startAt, item.endAt),
+    },
+    {
+      title: '수정일',
+      dataIndex: 'updatedAt',
+      key: 'updatedAt',
+      render: (value: string) => formatDateTime(value),
+    },
+    {
+      title: '액션',
+      key: 'actions',
+      render: (_: unknown, item: AnnouncementArchiveDoc) => (
+        <Space>
+          <Button size='small' type='primary' onClick={() => handleClickPublish(item)}>
+            발행
+          </Button>
+          <Button size='small' onClick={() => handleClickEdit(item)}>
+            편집
+          </Button>
+          <Button size='small' danger onClick={() => handleClickDelete(item)}>
+            삭제
+          </Button>
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <div>
+      <Card title='라이브 상태' style={{ marginBottom: 24 }}>
+        {liveDoc ? (
+          <>
+            <Descriptions column={1} size='small' style={{ marginBottom: 16 }}>
+              <Descriptions.Item label='id'>{liveDoc.id}</Descriptions.Item>
+              <Descriptions.Item label='상태'>
+                {liveDoc.active ? <Tag color='green'>ON</Tag> : <Tag>OFF</Tag>}
+              </Descriptions.Item>
+              <Descriptions.Item label='본문'>
+                <Typography.Text style={{ maxWidth: 400 }} ellipsis>
+                  {liveDoc.message}
+                </Typography.Text>
+              </Descriptions.Item>
+              <Descriptions.Item label='기간'>
+                {formatPeriod(liveDoc.startAt, liveDoc.endAt)}
+              </Descriptions.Item>
+            </Descriptions>
+            <Space>
+              <Button onClick={handleClickTurnOff} disabled={!liveDoc.active}>
+                끄기
+              </Button>
+              <Button danger onClick={handleClickTakeDown}>
+                내리기
+              </Button>
+            </Space>
+          </>
+        ) : (
+          <Typography.Text type='secondary'>발행된 항목 없음</Typography.Text>
+        )}
+      </Card>
+
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 12,
+        }}
+      >
+        <Typography.Title level={5} style={{ margin: 0 }}>
+          보관함
+        </Typography.Title>
+        <Button type='primary' onClick={handleClickCreate}>
+          새로 만들기
+        </Button>
+      </div>
+      <Table
+        rowKey='id'
+        columns={columns}
+        dataSource={archiveList}
+        pagination={false}
+        size='small'
+        locale={{ emptyText: '보관함이 비어 있습니다.' }}
+      />
+
+      <Modal
+        title={editingId ? '공지 편집' : '공지 작성'}
+        open={isModalOpen}
+        onOk={handleSubmitForm}
+        onCancel={handleCloseModal}
+        okText='보관함에 저장'
+        cancelText='취소'
+        confirmLoading={saving}
+        width={840}
+      >
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 24 }}>
+          <div style={{ flex: 1, minWidth: 320 }}>
+            <Form form={form} layout='vertical' disabled={saving} requiredMark>
+              <Form.Item
+                label='공지 id'
+                name='id'
+                rules={[{ required: true, message: 'id를 입력해주세요.' }]}
+                extra={
+                  editingId
+                    ? 'id를 바꾸면 새 항목으로 저장됩니다(기존 항목은 보관함에 남습니다).'
+                    : '보관함 문서 키로 사용됩니다. 예: 2026-summer-notice'
+                }
+              >
+                <Input placeholder='예: 2026-summer-notice' />
+              </Form.Item>
+
+              <Form.Item
+                label='본문'
+                name='message'
+                rules={[{ required: true, message: '본문을 입력해주세요.' }]}
+              >
+                <Input.TextArea rows={4} placeholder='배너에 표시할 본문' />
+              </Form.Item>
+
+              <Form.Item
+                label='링크 (선택)'
+                name='link'
+                extra='내부 경로는 /로 시작(예: /bag), 외부 링크는 http(s)://로 시작합니다.'
+              >
+                <Input placeholder='예: /bag 또는 https://example.com' />
+              </Form.Item>
+
+              <Form.Item label='노출 시작 (선택)' name='startAt'>
+                <DatePicker showTime style={{ width: '100%' }} placeholder='노출 시작 일시' />
+              </Form.Item>
+
+              <Form.Item label='노출 종료 (선택)' name='endAt'>
+                <DatePicker showTime style={{ width: '100%' }} placeholder='노출 종료 일시' />
+              </Form.Item>
+            </Form>
+          </div>
+          <div style={{ width: 340, flexShrink: 0 }}>
+            <AnnouncementPreview
+              message={watchedMessage ?? ''}
+              link={watchedLink?.trim() ? watchedLink.trim() : undefined}
+            />
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+};
+
+export default AnnouncementTabView;

--- a/src/announcement/FeaturePopupPreview.tsx
+++ b/src/announcement/FeaturePopupPreview.tsx
@@ -1,0 +1,216 @@
+import { FC, useState } from 'react';
+
+// 미리보기용 소개 항목 형태. 폼의 Form.List 값이 입력 중에는 부분값일 수 있어 전부 옵셔널로 받는다.
+interface PreviewItem {
+  imageUrl?: string;
+  title?: string;
+  description?: string;
+  link?: string;
+}
+
+// 앱 신기능 팝업 미리보기 props. 폼 입력값을 그대로 받아 렌더한다.
+interface Props {
+  title: string;
+  subtitle?: string;
+  items: PreviewItem[];
+  buttonLabel?: string;
+  showSkip: boolean;
+}
+
+const PREVIEW_FONT_FAMILY = "'Pretendard', -apple-system, 'Apple SD Gothic Neo', sans-serif";
+
+// 항목 썸네일. 이미지 로드 실패 시 img를 숨기고 회색 배경 박스로 폴백한다.
+const ItemThumb: FC<{ imageUrl?: string }> = ({ imageUrl }) => {
+  const [hasError, setHasError] = useState(false);
+
+  const handleError = () => {
+    setHasError(true);
+  };
+
+  return (
+    <div
+      style={{
+        width: 36,
+        height: 36,
+        borderRadius: 6,
+        backgroundColor: '#F1F1F1',
+        overflow: 'hidden',
+        flexShrink: 0,
+      }}
+    >
+      {imageUrl && !hasError && (
+        <img
+          src={imageUrl}
+          alt=''
+          style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+          onError={handleError}
+        />
+      )}
+    </div>
+  );
+};
+
+// 앱의 신기능 팝업(중앙 카드)을 폰 프레임 안에 축소 재현하는 순수 프레젠테이션 컴포넌트.
+const FeaturePopupPreview: FC<Props> = ({ title, subtitle, items, buttonLabel, showSkip }) => {
+  // 제목이 입력된 항목만 표시한다(입력 중인 빈 행 제외).
+  const visibleItems = items.filter((item) => !!item?.title);
+
+  return (
+    <div style={{ fontFamily: PREVIEW_FONT_FAMILY }}>
+      <div style={{ fontSize: 12, color: '#767676', marginBottom: 8 }}>앱 미리보기</div>
+      <div
+        style={{
+          width: 320,
+          height: 640,
+          backgroundColor: '#FFFFFF',
+          borderRadius: 16,
+          border: '1px solid #E5E5E5',
+          overflow: 'hidden',
+          position: 'relative',
+        }}
+      >
+        {/* 앱 화면 위에 깔리는 딤 */}
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            padding: '0 16px',
+          }}
+        >
+          {/* 중앙 카드 */}
+          <div
+            style={{
+              flex: 1,
+              backgroundColor: '#FFFFFF',
+              borderRadius: 16,
+              padding: 20,
+            }}
+          >
+            {title ? (
+              <div
+                style={{
+                  fontSize: 18,
+                  lineHeight: '25px',
+                  fontWeight: 700,
+                  color: '#000000',
+                  textAlign: 'center',
+                  whiteSpace: 'pre-wrap',
+                }}
+              >
+                {title}
+              </div>
+            ) : (
+              <div
+                style={{
+                  fontSize: 18,
+                  lineHeight: '25px',
+                  fontWeight: 700,
+                  color: '#B0B8C1',
+                  textAlign: 'center',
+                }}
+              >
+                제목을 입력하세요
+              </div>
+            )}
+            {subtitle && (
+              <div
+                style={{
+                  marginTop: 8,
+                  fontSize: 12.5,
+                  lineHeight: '18px',
+                  color: '#767676',
+                  textAlign: 'center',
+                }}
+              >
+                {subtitle}
+              </div>
+            )}
+            {visibleItems.length > 0 && (
+              <div
+                style={{
+                  marginTop: 16,
+                  border: '1px solid #E5E5E5',
+                  borderRadius: 8,
+                  overflow: 'hidden',
+                }}
+              >
+                {visibleItems.map((item, index) => (
+                  <div
+                    key={index}
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                      gap: 10,
+                      padding: '10px 12px',
+                      borderBottom:
+                        index < visibleItems.length - 1 ? '1px solid #F0F0F0' : 'none',
+                    }}
+                  >
+                    <ItemThumb imageUrl={item.imageUrl} />
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div
+                        style={{
+                          fontSize: 12.5,
+                          lineHeight: '17px',
+                          fontWeight: 600,
+                          color: '#000000',
+                        }}
+                      >
+                        {item.title}
+                      </div>
+                      {item.description && (
+                        <div style={{ fontSize: 11, lineHeight: '15px', color: '#767676' }}>
+                          {item.description}
+                        </div>
+                      )}
+                    </div>
+                    {item.link && (
+                      <div style={{ fontSize: 16, color: '#B0B8C1', flexShrink: 0 }}>›</div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+            <div
+              style={{
+                marginTop: 16,
+                height: 44,
+                borderRadius: 22,
+                backgroundColor: '#000000',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 14,
+                fontWeight: 700,
+                color: '#FFFFFF',
+              }}
+            >
+              {buttonLabel || '확인'}
+            </div>
+            {showSkip && (
+              <div
+                style={{
+                  marginTop: 8,
+                  height: 32,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: 13,
+                  color: '#555555',
+                }}
+              >
+                건너뛰기
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FeaturePopupPreview;

--- a/src/announcement/FeaturePopupTabView.tsx
+++ b/src/announcement/FeaturePopupTabView.tsx
@@ -1,0 +1,658 @@
+import { useEffect, useState } from 'react';
+import {
+  Button,
+  Card,
+  DatePicker,
+  Descriptions,
+  Form,
+  Input,
+  message,
+  Modal,
+  Space,
+  Spin,
+  Switch,
+  Table,
+  Tag,
+  Typography,
+} from 'antd';
+import { Dayjs } from 'dayjs';
+import { collection, deleteDoc, doc, getDoc, getDocs, orderBy, query, setDoc } from 'firebase/firestore';
+import app from '../App';
+import { formatDateTime, formatPeriod, toDayjs, toIsoString } from './AdminDateUtil';
+import FeaturePopupPreview from './FeaturePopupPreview';
+
+// 팝업 항목(카드 리스트 한 줄) 형태 — 앱은 앞 3개만 렌더한다.
+interface FeaturePopupItem {
+  imageUrl?: string;
+  title: string;
+  description?: string;
+  link?: string;
+}
+
+// 작성/편집 폼 값 형태. 날짜는 antd DatePicker와 맞물리도록 Dayjs로 다룬다.
+interface FeaturePopupFormValues {
+  id: string;
+  title: string;
+  subtitle?: string;
+  items?: { imageUrl?: string; title: string; description?: string; link?: string }[];
+  buttonLabel?: string;
+  buttonLink?: string;
+  showSkip: boolean;
+  startAt?: Dayjs;
+  endAt?: Dayjs;
+}
+
+// 보관함(feature-popups/{id}) 문서 형태. 선택 필드는 값이 있을 때만 포함한다.
+interface FeaturePopupArchiveDoc {
+  id: string;
+  title: string;
+  subtitle?: string;
+  items?: FeaturePopupItem[];
+  buttonLabel?: string;
+  buttonLink?: string;
+  showSkip: boolean;
+  startAt?: string;
+  endAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// 라이브(config/featurePopup) 문서 형태 — 앱이 실시간 구독하는 계약이므로 변경 금지.
+interface FeaturePopupLiveDoc {
+  id: string;
+  active: boolean;
+  title: string;
+  subtitle?: string;
+  items?: FeaturePopupItem[];
+  buttonLabel?: string;
+  buttonLink?: string;
+  showSkip: boolean;
+  startAt?: string;
+  endAt?: string;
+}
+
+const LIVE_DOC_PATH = ['config', 'featurePopup'] as const;
+const ARCHIVE_COLLECTION = 'feature-popups';
+const MAX_ITEMS = 3;
+
+const FeaturePopupTabView = () => {
+  const [form] = Form.useForm<FeaturePopupFormValues>();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [liveDoc, setLiveDoc] = useState<FeaturePopupLiveDoc | null>(null);
+  const [archiveList, setArchiveList] = useState<FeaturePopupArchiveDoc[]>([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  // 미리보기 실시간 갱신용 폼 값 구독(Modal이 닫혀 있어도 안전).
+  const watchedTitle = Form.useWatch('title', form);
+  const watchedSubtitle = Form.useWatch('subtitle', form);
+  const watchedItems = Form.useWatch('items', form);
+  const watchedButtonLabel = Form.useWatch('buttonLabel', form);
+  const watchedShowSkip = Form.useWatch('showSkip', form);
+
+  const firebase = app.getFirebase();
+
+  const getLiveDocRef = () => {
+    return doc(firebase.getStore(), ...LIVE_DOC_PATH);
+  };
+
+  const getArchiveDocRef = (id: string) => {
+    return doc(firebase.getStore(), ARCHIVE_COLLECTION, id);
+  };
+
+  const loadLive = async () => {
+    const snapshot = await getDoc(getLiveDocRef());
+
+    if (snapshot.exists()) {
+      setLiveDoc(snapshot.data() as FeaturePopupLiveDoc);
+    } else {
+      setLiveDoc(null);
+    }
+  };
+
+  const loadArchive = async () => {
+    const snapshot = await getDocs(
+      query(collection(firebase.getStore(), ARCHIVE_COLLECTION), orderBy('updatedAt', 'desc'))
+    );
+
+    setArchiveList(snapshot.docs.map((item) => item.data() as FeaturePopupArchiveDoc));
+  };
+
+  // 진입 시 라이브 문서와 보관함 목록을 1회 조회한다.
+  useEffect(() => {
+    const loadAll = async () => {
+      try {
+        await Promise.all([loadLive(), loadArchive()]);
+      } catch (error) {
+        console.error('신기능 팝업 데이터 로드 실패:', error);
+        message.error('신기능 팝업 데이터를 불러오지 못했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadAll();
+  }, []);
+
+  // 항목 배열의 선택 필드를 정리한다(빈 문자열 저장 금지).
+  const buildItems = (items?: FeaturePopupFormValues['items']): FeaturePopupItem[] => {
+    if (!items) {
+      return [];
+    }
+
+    return items.map((item) => {
+      const built: FeaturePopupItem = { title: item.title.trim() };
+
+      const imageUrl = item.imageUrl?.trim();
+
+      if (imageUrl) {
+        built.imageUrl = imageUrl;
+      }
+
+      const description = item.description?.trim();
+
+      if (description) {
+        built.description = description;
+      }
+
+      const link = item.link?.trim();
+
+      if (link) {
+        built.link = link;
+      }
+
+      return built;
+    });
+  };
+
+  // 폼 값을 보관함 문서 형태로 변환. 선택 필드가 비면 키를 넣지 않는다(빈 문자열 저장 금지).
+  const buildArchivePayload = (values: FeaturePopupFormValues): FeaturePopupArchiveDoc => {
+    const id = values.id.trim();
+    const existing = archiveList.find((item) => item.id === id);
+    const now = new Date().toISOString();
+
+    const payload: FeaturePopupArchiveDoc = {
+      id,
+      title: values.title.trim(),
+      showSkip: !!values.showSkip,
+      createdAt: existing ? existing.createdAt : now,
+      updatedAt: now,
+    };
+
+    const subtitle = values.subtitle?.trim();
+
+    if (subtitle) {
+      payload.subtitle = subtitle;
+    }
+
+    const items = buildItems(values.items);
+
+    if (items.length > 0) {
+      payload.items = items;
+    }
+
+    const buttonLabel = values.buttonLabel?.trim();
+
+    if (buttonLabel) {
+      payload.buttonLabel = buttonLabel;
+    }
+
+    const buttonLink = values.buttonLink?.trim();
+
+    if (buttonLink) {
+      payload.buttonLink = buttonLink;
+    }
+
+    const startAt = toIsoString(values.startAt);
+
+    if (startAt) {
+      payload.startAt = startAt;
+    }
+
+    const endAt = toIsoString(values.endAt);
+
+    if (endAt) {
+      payload.endAt = endAt;
+    }
+
+    return payload;
+  };
+
+  // 보관함 항목의 콘텐츠 필드만 라이브 문서 형태로 변환(createdAt/updatedAt 제외, active: true).
+  const buildLivePayload = (item: FeaturePopupArchiveDoc): FeaturePopupLiveDoc => {
+    const payload: FeaturePopupLiveDoc = {
+      id: item.id,
+      active: true,
+      title: item.title,
+      showSkip: item.showSkip,
+    };
+
+    if (item.subtitle) {
+      payload.subtitle = item.subtitle;
+    }
+
+    if (item.items && item.items.length > 0) {
+      payload.items = item.items;
+    }
+
+    if (item.buttonLabel) {
+      payload.buttonLabel = item.buttonLabel;
+    }
+
+    if (item.buttonLink) {
+      payload.buttonLink = item.buttonLink;
+    }
+
+    if (item.startAt) {
+      payload.startAt = item.startAt;
+    }
+
+    if (item.endAt) {
+      payload.endAt = item.endAt;
+    }
+
+    return payload;
+  };
+
+  const handleClickCreate = () => {
+    setEditingId(null);
+    form.resetFields();
+    setIsModalOpen(true);
+  };
+
+  const handleClickEdit = (item: FeaturePopupArchiveDoc) => {
+    setEditingId(item.id);
+    form.setFieldsValue({
+      id: item.id,
+      title: item.title,
+      subtitle: item.subtitle ?? '',
+      items: (item.items ?? []).map((entry) => ({
+        imageUrl: entry.imageUrl ?? '',
+        title: entry.title,
+        description: entry.description ?? '',
+        link: entry.link ?? '',
+      })),
+      buttonLabel: item.buttonLabel ?? '',
+      buttonLink: item.buttonLink ?? '',
+      showSkip: item.showSkip ?? true,
+      startAt: toDayjs(item.startAt),
+      endAt: toDayjs(item.endAt),
+    });
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
+
+  // 보관함에 저장(문서 키 = id). 편집 중 id를 바꾸면 새 항목으로 저장되고 기존 항목은 남는다.
+  const handleSubmitForm = async () => {
+    let values: FeaturePopupFormValues;
+
+    try {
+      values = await form.validateFields();
+    } catch {
+      // 필수값 누락 안내는 폼이 담당.
+      return;
+    }
+
+    setSaving(true);
+
+    try {
+      const payload = buildArchivePayload(values);
+
+      await setDoc(getArchiveDocRef(payload.id), payload);
+      await loadArchive();
+      setIsModalOpen(false);
+      message.success('보관함에 저장되었습니다.');
+    } catch (error) {
+      console.error('신기능 팝업 저장 실패:', error);
+      message.error('저장에 실패했습니다.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // 발행: 보관함 항목을 active: true로 라이브 문서에 전체 덮어쓰기.
+  // 팝업 닫음은 id 단위 영구라, 라이브와 다른 id를 발행하면 닫았던 사용자에게도 다시 뜬다.
+  const handleClickPublish = (item: FeaturePopupArchiveDoc) => {
+    const isNewId = !!liveDoc && liveDoc.id !== item.id;
+
+    Modal.confirm({
+      title: '이 항목을 라이브로 발행할까요?',
+      content: isNewId
+        ? `⚠️ 현재 라이브 팝업(id: ${liveDoc?.id})과 id가 다릅니다. 팝업 닫음은 id 단위로 영구 저장되므로, 이전 팝업을 닫았던 모든 사용자에게 새로 노출됩니다.`
+        : `id "${item.id}" 항목이 앱에 즉시 노출됩니다.`,
+      okText: '발행',
+      cancelText: '취소',
+      onOk: async () => {
+        try {
+          const payload = buildLivePayload(item);
+
+          await setDoc(getLiveDocRef(), payload);
+          setLiveDoc(payload);
+          message.success('발행되었습니다.');
+        } catch (error) {
+          console.error('신기능 팝업 발행 실패:', error);
+          message.error('발행에 실패했습니다.');
+        }
+      },
+    });
+  };
+
+  // 끄기: 라이브 문서는 두고 active만 false로 저장해 노출만 중단한다.
+  const handleClickTurnOff = async () => {
+    if (!liveDoc) {
+      return;
+    }
+
+    try {
+      const payload: FeaturePopupLiveDoc = { ...liveDoc, active: false };
+
+      await setDoc(getLiveDocRef(), payload);
+      setLiveDoc(payload);
+      message.success('노출을 껐습니다.');
+    } catch (error) {
+      console.error('신기능 팝업 끄기 실패:', error);
+      message.error('끄기에 실패했습니다.');
+    }
+  };
+
+  // 내리기: 라이브 문서를 삭제해 팝업을 완전히 제거한다(보관함은 유지).
+  const handleClickTakeDown = () => {
+    Modal.confirm({
+      title: '라이브 팝업을 내리시겠습니까?',
+      content: '라이브 문서가 삭제되어 앱에서 팝업이 완전히 사라집니다. 보관함 항목은 유지됩니다.',
+      okText: '내리기',
+      okButtonProps: { danger: true },
+      cancelText: '취소',
+      onOk: async () => {
+        try {
+          await deleteDoc(getLiveDocRef());
+          setLiveDoc(null);
+          message.success('라이브 팝업을 내렸습니다.');
+        } catch (error) {
+          console.error('신기능 팝업 내리기 실패:', error);
+          message.error('내리기에 실패했습니다.');
+        }
+      },
+    });
+  };
+
+  // 보관함 항목 삭제: 보관함에서만 지우며 라이브 노출에는 영향이 없다.
+  const handleClickDelete = (item: FeaturePopupArchiveDoc) => {
+    Modal.confirm({
+      title: '보관함에서 삭제하시겠습니까?',
+      content: '보관함에서만 삭제되며, 라이브 노출에는 영향이 없습니다.',
+      okText: '삭제',
+      okButtonProps: { danger: true },
+      cancelText: '취소',
+      onOk: async () => {
+        try {
+          await deleteDoc(getArchiveDocRef(item.id));
+          await loadArchive();
+          message.success('삭제되었습니다.');
+        } catch (error) {
+          console.error('신기능 팝업 보관함 삭제 실패:', error);
+          message.error('삭제에 실패했습니다.');
+        }
+      },
+    });
+  };
+
+  if (loading) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', padding: '60px 0' }}>
+        <Spin />
+      </div>
+    );
+  }
+
+  const columns = [
+    {
+      title: 'id',
+      dataIndex: 'id',
+      key: 'id',
+      render: (id: string) => (
+        <Space>
+          <span>{id}</span>
+          {liveDoc?.id === id && <Tag color='green'>LIVE</Tag>}
+        </Space>
+      ),
+    },
+    {
+      title: '요약',
+      dataIndex: 'title',
+      key: 'title',
+      render: (value: string) => (
+        <Typography.Text style={{ maxWidth: 240 }} ellipsis>
+          {value}
+        </Typography.Text>
+      ),
+    },
+    {
+      title: '기간',
+      key: 'period',
+      render: (_: unknown, item: FeaturePopupArchiveDoc) => formatPeriod(item.startAt, item.endAt),
+    },
+    {
+      title: '수정일',
+      dataIndex: 'updatedAt',
+      key: 'updatedAt',
+      render: (value: string) => formatDateTime(value),
+    },
+    {
+      title: '액션',
+      key: 'actions',
+      render: (_: unknown, item: FeaturePopupArchiveDoc) => (
+        <Space>
+          <Button size='small' type='primary' onClick={() => handleClickPublish(item)}>
+            발행
+          </Button>
+          <Button size='small' onClick={() => handleClickEdit(item)}>
+            편집
+          </Button>
+          <Button size='small' danger onClick={() => handleClickDelete(item)}>
+            삭제
+          </Button>
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <div>
+      <Card title='라이브 상태' style={{ marginBottom: 24 }}>
+        {liveDoc ? (
+          <>
+            <Descriptions column={1} size='small' style={{ marginBottom: 16 }}>
+              <Descriptions.Item label='id'>{liveDoc.id}</Descriptions.Item>
+              <Descriptions.Item label='상태'>
+                {liveDoc.active ? <Tag color='green'>ON</Tag> : <Tag>OFF</Tag>}
+              </Descriptions.Item>
+              <Descriptions.Item label='제목'>
+                <Typography.Text style={{ maxWidth: 400 }} ellipsis>
+                  {liveDoc.title}
+                </Typography.Text>
+              </Descriptions.Item>
+              <Descriptions.Item label='기간'>
+                {formatPeriod(liveDoc.startAt, liveDoc.endAt)}
+              </Descriptions.Item>
+            </Descriptions>
+            <Space>
+              <Button onClick={handleClickTurnOff} disabled={!liveDoc.active}>
+                끄기
+              </Button>
+              <Button danger onClick={handleClickTakeDown}>
+                내리기
+              </Button>
+            </Space>
+          </>
+        ) : (
+          <Typography.Text type='secondary'>발행된 항목 없음</Typography.Text>
+        )}
+      </Card>
+
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 12,
+        }}
+      >
+        <Typography.Title level={5} style={{ margin: 0 }}>
+          보관함
+        </Typography.Title>
+        <Button type='primary' onClick={handleClickCreate}>
+          새로 만들기
+        </Button>
+      </div>
+      <Table
+        rowKey='id'
+        columns={columns}
+        dataSource={archiveList}
+        pagination={false}
+        size='small'
+        locale={{ emptyText: '보관함이 비어 있습니다.' }}
+      />
+
+      <Modal
+        title={editingId ? '신기능 팝업 편집' : '신기능 팝업 작성'}
+        open={isModalOpen}
+        onOk={handleSubmitForm}
+        onCancel={handleCloseModal}
+        okText='보관함에 저장'
+        cancelText='취소'
+        confirmLoading={saving}
+        width={960}
+      >
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 24 }}>
+          <div style={{ flex: 1, minWidth: 360 }}>
+            <Form
+              form={form}
+              layout='vertical'
+              disabled={saving}
+              requiredMark
+              initialValues={{ showSkip: true }}
+            >
+              <Form.Item
+                label='팝업 id'
+                name='id'
+                rules={[{ required: true, message: 'id를 입력해주세요.' }]}
+                extra={
+                  editingId
+                    ? 'id를 바꾸면 새 항목으로 저장됩니다(기존 항목은 보관함에 남습니다). 팝업 닫음은 id 단위 영구라 새 id 발행 시 모두에게 다시 뜹니다.'
+                    : '보관함 문서 키로 사용됩니다. 예: 2026-07-feature-popup'
+                }
+              >
+                <Input placeholder='예: 2026-07-feature-popup' />
+              </Form.Item>
+
+              <Form.Item
+                label='제목'
+                name='title'
+                rules={[{ required: true, message: '제목을 입력해주세요.' }]}
+                extra='줄바꿈이 그대로 표시됩니다.'
+              >
+                <Input.TextArea rows={2} placeholder='팝업 상단 제목' />
+              </Form.Item>
+
+              <Form.Item label='부제목 (선택)' name='subtitle'>
+                <Input placeholder='제목 아래 보조 문구' />
+              </Form.Item>
+
+              <Form.Item label={`소개 항목 (최대 ${MAX_ITEMS}개 — 앱은 앞 3개만 표시)`}>
+                <Form.List name='items'>
+                  {(fields, { add, remove }) => (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                      {fields.map((field) => (
+                        <Card
+                          key={field.key}
+                          size='small'
+                          title={`항목 ${field.name + 1}`}
+                          extra={
+                            <Button size='small' danger type='text' onClick={() => remove(field.name)}>
+                              삭제
+                            </Button>
+                          }
+                        >
+                          <Form.Item label='이미지 URL (선택)' name={[field.name, 'imageUrl']}>
+                            <Input placeholder='https://...' />
+                          </Form.Item>
+                          <Form.Item
+                            label='항목 제목'
+                            name={[field.name, 'title']}
+                            rules={[{ required: true, message: '항목 제목을 입력해주세요.' }]}
+                          >
+                            <Input placeholder='기능 이름' />
+                          </Form.Item>
+                          <Form.Item label='설명 (선택)' name={[field.name, 'description']}>
+                            <Input placeholder='한 줄 설명' />
+                          </Form.Item>
+                          <Form.Item
+                            label='링크 (선택)'
+                            name={[field.name, 'link']}
+                            style={{ marginBottom: 0 }}
+                          >
+                            <Input placeholder='예: /bag 또는 https://example.com' />
+                          </Form.Item>
+                        </Card>
+                      ))}
+                      {fields.length < MAX_ITEMS && (
+                        <Button type='dashed' onClick={() => add()} block>
+                          + 항목 추가
+                        </Button>
+                      )}
+                    </div>
+                  )}
+                </Form.List>
+              </Form.Item>
+
+              <Form.Item
+                label='버튼 문구 (선택)'
+                name='buttonLabel'
+                extra='비우면 앱 기본값 "확인"이 사용됩니다.'
+              >
+                <Input placeholder='예: 지금 써보기' />
+              </Form.Item>
+
+              <Form.Item label='버튼 링크 (선택)' name='buttonLink'>
+                <Input placeholder='예: /bag 또는 https://example.com' />
+              </Form.Item>
+
+              <Form.Item
+                label='건너뛰기 노출'
+                name='showSkip'
+                valuePropName='checked'
+                extra='끄면 팝업에 "건너뛰기"가 표시되지 않습니다.'
+              >
+                <Switch checkedChildren='ON' unCheckedChildren='OFF' />
+              </Form.Item>
+
+              <Form.Item label='노출 시작 (선택)' name='startAt'>
+                <DatePicker showTime style={{ width: '100%' }} placeholder='노출 시작 일시' />
+              </Form.Item>
+
+              <Form.Item label='노출 종료 (선택)' name='endAt'>
+                <DatePicker showTime style={{ width: '100%' }} placeholder='노출 종료 일시' />
+              </Form.Item>
+            </Form>
+          </div>
+          <div style={{ width: 340, flexShrink: 0 }}>
+            <FeaturePopupPreview
+              title={watchedTitle ?? ''}
+              subtitle={watchedSubtitle?.trim() ? watchedSubtitle.trim() : undefined}
+              items={watchedItems ?? []}
+              buttonLabel={watchedButtonLabel?.trim() ? watchedButtonLabel.trim() : undefined}
+              showSkip={watchedShowSkip ?? true}
+            />
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+};
+
+export default FeaturePopupTabView;

--- a/src/common/AllowedUids.ts
+++ b/src/common/AllowedUids.ts
@@ -1,0 +1,4 @@
+// 어드민 화면(장비 관리 / 공지) 접근이 허용된 운영자 UID 목록.
+// manage와 announcement 화면이 동일한 운영자 기준을 공유하기 위해 이곳에 단일 정의한다.
+// ⚠️ 클라이언트 사이드 게이팅이며, 실제 쓰기 보호는 Firestore 보안 규칙에 의존한다.
+export const ALLOWED_UIDS = ['M3yk9SzrGZN3veiyd2SE6LmTrsk1', 'KkmaLpxPYLbmJKGkSTLMuMcD5l82'];

--- a/src/manage/ManageView.tsx
+++ b/src/manage/ManageView.tsx
@@ -9,6 +9,7 @@ import AddGearModal from './component/AddGearModal';
 import AddGearExcelModal from './component/AddGearExcelModal';
 import NaverShoppingImageModal from './component/NaverShoppingImageModal';
 import SaveKoreanNameButtonView from './SaveKoreanNameButtonView';
+import { ALLOWED_UIDS } from '../common/AllowedUids';
 
 interface RowType {
   id: string;
@@ -49,7 +50,6 @@ const ManageView = () => {
   const firebase = app.getFirebase();
   const isLoggedIn = firebase.isLoggedIn();
   const userId = firebase.getUserId();
-  const ALLOWED_UIDS = ['M3yk9SzrGZN3veiyd2SE6LmTrsk1', 'KkmaLpxPYLbmJKGkSTLMuMcD5l82'];
 
   const handleClickGoogle = async () => {
     await firebase.logInWithGoogle();


### PR DESCRIPTION
## 개요

앱의 인앱 공지(`config/announcement`)와 신기능 안내 팝업(`config/featurePopup`)을 관리하는 어드민 화면을 추가합니다. Google 로그인 + 허용 UID(manage와 공용)만 접근 가능합니다.

## 구성 (`/announcement`)

탭 2개(공지 / 신기능 팝업), 각 탭 동일 구조:

- **라이브 상태 카드**: 현재 발행된 문서 요약(id·내용·ON/OFF·기간) + 끄기(active만 false) / 내리기(라이브 삭제)
- **보관함 목록**(최신순): 라이브와 같은 id엔 LIVE 태그, 행별 발행/편집/삭제
- **작성/편집 모달**: 좌측 폼 + 우측 **폰 프레임 실시간 미리보기**(`Form.useWatch`) — 공지=바텀 시트, 팝업=중앙 카드 재현
- 팝업 폼: 아이템 최대 3개 Form.List(썸네일URL·제목·설명·링크), 건너뛰기 스위치, 버튼 라벨(비면 앱 기본 '확인')

## 데이터 모델 (보관함 + 발행)

- 보관함 컬렉션 `announcements/{id}` · `feature-popups/{id}` — 어드민 전용, **앱은 읽지 않음**
- **발행** = 항목 콘텐츠를 라이브 문서(`config/*`)에 `active:true`로 전체 덮어쓰기 — 라이브는 항상 1개, **앱 변경 불필요**
- 라이브와 다른 id 발행 시 "닫았던 사용자에게도 재노출" 경고 confirm(팝업은 id 단위 영구 닫음이라 강조)
- 보관함 삭제는 라이브에 영향 없음

## 기타

- `ALLOWED_UIDS`를 `src/common/AllowedUids.ts`로 추출해 manage와 공용화
- 스펙: `docs/announcement/AnnouncementAdminSpec.md`

## 검증

- `tsc -b` / `eslint` 0 errors, `vite build` 성공
- 로그인 후 실사용 테스트 완료(작성→발행→앱 표시, 미리보기 실시간 갱신)

## 배포 전 필요 (별도 작업)

Firestore 보안 규칙: `config/*` 공개 읽기 + 어드민 UID만 쓰기, `announcements/**`·`feature-popups/**` 어드민 UID만 읽기/쓰기

🤖 Generated with [Claude Code](https://claude.com/claude-code)