### PR TITLE
호스팅 캐시 헤더 — HTML no-cache, 해시 에셋 1년 immutable

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -11,6 +11,26 @@
         "source": "**",
         "destination": "/index.html"
       }
+    ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
+        "source": "/assets/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=31536000, immutable"
+          }
+        ]
+      }
     ]
   },
   "functions": [


### PR DESCRIPTION
## 문제

`index.html`이 Firebase Hosting 기본값(`max-age=3600`)으로 브라우저에 1시간 캐시됩니다. 배포 직후 이전 방문자는 옛 index.html(옛 번들)을 계속 쓰게 되어, 이번 `/announcement` 어드민 배포 후 "로그인 버튼이 안 뜨는"(옛 라우터의 fallback으로 빠짐) 현상이 발생했습니다.

## 수정

SPA 표준 캐시 전략:
- `**` (HTML 등): `Cache-Control: no-cache` — 매 방문 시 재검증, 배포 즉시 반영
- `/assets/**` (콘텐츠 해시 파일): `public, max-age=31536000, immutable` — 1년 캐시(파일명이 바뀌므로 안전)

## 검증

머지 후 `firebase deploy --only hosting` 재배포 → `curl -I https://useless.my/announcement`에서 `cache-control: no-cache` 확인 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)